### PR TITLE
Rename (allthethings) from riakshell to riak_shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-REPO            ?= riakshell
+REPO            ?= riak_shell
 # packagers need hyphens not underscores
 APP              = $(shell echo "$(REPO)" | sed -e 's/_/-/g')
 PKG_REVISION    ?= $(shell git describe --tags)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Riakshell
+riak_shell
 ---------
 
 A configurable, scriptable and extendable shell for riak.
@@ -6,7 +6,7 @@ A configurable, scriptable and extendable shell for riak.
 Goals
 -----
 
-The goals of riakshell are to have a single shell that can:
+The goals of riak_shell are to have a single shell that can:
 * run sql commands
 * run riak-admin commands
 * be used a developer/devops tool for managing riak clusters
@@ -47,18 +47,18 @@ Running/Getting Started
 -----------------------
 
 ```
-cd ~/riakshell/bin
-./riakshell
+cd ~/riak_shell/bin
+./riak_shell
 ```
 
-You get help on what is implemented in the riakshell with the help command:
+You get help on what is implemented in the riak_shell with the help command:
 ```
-riakshell (1)> help;
+riak_shell (1)> help;
 ```
 
 The current state is:
 ```
-riakshell(1)>help;
+riak_shell(1)>help;
 The following functions are available
 (the number of arguments is given)
 
@@ -105,15 +105,15 @@ Configuration
 
 Configuration is in the file:
 ```
-~/riakshell/etc/riakshell.config
+~/riak_shell/etc/riak_shell.config
 ```
 
 The following things can be configured:
 ```
 logging                = on | off
 date_log               = on | off
-logfile                = "../some/dir/mylogfile.log" defaults to "../log/riakshell.log"
-cookie                 = any erlang atom - the underlying Erlang cookie riakshell uses to connect
+logfile                = "../some/dir/mylogfile.log" defaults to "../log/riak_shell.log"
+cookie                 = any erlang atom - the underlying Erlang cookie riak_shell uses to connect
 show_connection_status = true | false show the green tick or red cross in the command line
 nodes                  = [ nodenames] a list of nodes to try and connect to on startup or 'reconnect;'
 ```
@@ -123,38 +123,38 @@ Command Line Flags
 
 There are 4 different configurations, two of which trigger batch mode.
 
-By default riakshell swallows error messages, this makes it hard to develop new extentions. You can run it in debug mode as shown below:
+By default riak_shell swallows error messages, this makes it hard to develop new extentions. You can run it in debug mode as shown below:
 ``` 
-./riakshell -d
+./riak_shell -d
 ```
 
-You can pass in a different config file than `../etc/riakshell.config`:
+You can pass in a different config file than `../etc/riak_shell.config`:
 ```
-./riakshell -c ../path/to/my.config
-```
-
-You can run a riakshell replay log for batch/scripting:
-```
-./riakshell -f ../path/to/my.log
+./riak_shell -c ../path/to/my.config
 ```
 
-You can run a riakshell regression log for batch/scripting:
+You can run a riak_shell replay log for batch/scripting:
 ```
-./riakshell -r ../path/to/my.log
+./riak_shell -f ../path/to/my.log
 ```
 
-Extending The Riakshell
+You can run a riak_shell regression log for batch/scripting:
+```
+./riak_shell -r ../path/to/my.log
+```
+
+Extending The riak_shell
 -----------------------
 
-Riakshell uses a 'magic' architecture with convention.
+riak_shell uses a 'magic' architecture with convention.
 
 Riak modules with names like:
 ```
 mymodule_EXT.erl
 ```
-are considered to be riakshell extension modules.
+are considered to be riak_shell extension modules.
 
-All exported functions with an arity >= 1 are automaticaly exposed in riakshell mode, with come exceptions.
+All exported functions with an arity >= 1 are automaticaly exposed in riak_shell mode, with come exceptions.
 
 Exported functions with the following names will be silently ignored:
 * `module_info/0`
@@ -167,11 +167,11 @@ Functions that share a name with the first keyword of supported SQL statements w
 * `describe/N`
 * `select/N`
 
-As additional SQL statements are supported adding them to the macro `IMPLEMENTED_SQL_STATEMENTS` in `riakshell.hrl` will automatically make them available to riakshell and exclude them from extensions.
+As additional SQL statements are supported adding them to the macro `IMPLEMENTED_SQL_STATEMENTS` in `riak_shell.hrl` will automatically make them available to riak_shell and exclude them from extensions.
 
 To add a function which appears to the user like:
 ```
-riakshell (12)> frobulator bish bash bosh;
+riak_shell (12)> frobulator bish bash bosh;
 ```
 
 You implement a function with the following signature:
@@ -195,7 +195,7 @@ To be a good citizen you should add a clause to the help function like:
     "This is how you use my function";
 ```
 
-If you have a function with the same name that appears in 2 EXT modules riakshell will not start. It will not check if the arities match. You may have the same function with different arities in the same module - but there is only one help call.
+If you have a function with the same name that appears in 2 EXT modules riak_shell will not start. It will not check if the arities match. You may have the same function with different arities in the same module - but there is only one help call.
 
 As a convenience to the developer there is a module called:
 ```
@@ -204,14 +204,14 @@ debug_EXT.erl
 
 This implements a function which reloads and reregisters all extensions:
 ```
-riakshell (11)>load;
+riak_shell (11)>load;
 ```
 and can hot-load changes into the shell (it won't work on first-creation of a new EXT module, only on reloading). The only EXT that debug doesn't load is `debug_EXT` so please do not add functions to it.
 
-The riakshell suppresses error messages that would otherwise be written to the console (for instance if the remote riak node goes down the protocol buffer connection is torn down). This makes debugging painful. You can stop this behaviour by starting riakshell in the debug mode by starting it from the shell with the `-d` flag:
+The riak_shell suppresses error messages that would otherwise be written to the console (for instance if the remote riak node goes down the protocol buffer connection is torn down). This makes debugging painful. You can stop this behaviour by starting riak_shell in the debug mode by starting it from the shell with the `-d` flag:
 ```
-cd ~/riakshell/bin
-./riakshell -d
+cd ~/riak_shell/bin
+./riak_shell -d
 ```
 
 Architecture Notes

--- a/bin/riak-shell
+++ b/bin/riak-shell
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 # Try and make bash work safely
-# Terminate on an unitiatlised varialbe
+# Terminate on an uninitialised variable
 set -u
-# Termiate on error
+# Terminate on error
 set -e
 # Terminate if any part of a pipeline fail
 set -o pipefail
@@ -14,7 +14,7 @@ set -o pipefail
 # gotta initialise OPTARG there
 OPTARG=""
 DEBUG="debug_off"
-CONFIG="../etc/riakshell"
+CONFIG="../etc/riak_shell"
 RUNFILE=false
 FILETORUN=""
 RUNFILEAS=""
@@ -47,4 +47,4 @@ while getopts "c:df:r:" OPT; do
    esac
 done
 
-erl -run riakshell_app boot $DEBUG $FILETORUN $RUNFILEAS -noshell -config $CONFIG -noinput -pa ../ebin -pa ../deps/*/ebin -name riakshell@127.0.0.1
+erl -run riak_shell_app boot $DEBUG $FILETORUN $RUNFILEAS -noshell -config $CONFIG -noinput -pa ../ebin -pa ../deps/*/ebin -name riak_shell@127.0.0.1

--- a/etc/riak_shell.config
+++ b/etc/riak_shell.config
@@ -1,6 +1,6 @@
 %%% -*- erlang -*-
 [
- {riakshell, [
+ {riak_shell, [
               {logging, on},
               {cookie, riak},
               {show_connection_status, true},

--- a/include/riak_shell.hrl
+++ b/include/riak_shell.hrl
@@ -1,9 +1,9 @@
--define(CONFIGFILE, "../etc/riakshell.config").
+-define(CONFIGFILE, "../etc/riak_shell.config").
 -define(GREENTICK, [9989]).
 -define(REDCROSS,  [10060]).
 
 -record(state, {
-          version                = "riakshell 0.9/sql 1.2",
+          version                = "riak_shell 0.9/sql 1.2",
           count                  = 1   :: integer(),
           extensions             = [],
           history                = [],
@@ -11,10 +11,10 @@
           has_connection         = false :: boolean,
           connection             = none,
           cookie                 = riak,
-          logfile                = "../log/riakshell",
+          logfile                = "../log/riak_shell",
           logging                = off :: on | off,
           date_log               = off :: on | off,
-          current_date           = riakshell_util:datetime(),
+          current_date           = riak_shell_util:datetime(),
           show_connection_status = false,
           %% these fields are used to convey information about the
           %% the current execution loop, is the command complete

--- a/src/cmdline_lexer.xrl
+++ b/src/cmdline_lexer.xrl
@@ -1,7 +1,7 @@
 %%% -*- mode: erlang -*-
 %% -------------------------------------------------------------------
 %%
-%% A lexer for the command line of riakshell
+%% A lexer for the command line of riak_shell
 %%
 %% Copyright (c) 2007-2016 Basho Technologies, Inc.  All Rights Reserved.
 %%

--- a/src/cmdline_parser.yrl
+++ b/src/cmdline_parser.yrl
@@ -1,7 +1,7 @@
 %% -*- erlang -*-
 %% -------------------------------------------------------------------
 %%
-%% The parser for the command line of riakshell
+%% The parser for the command line of riak_shell
 %%
 %% Copyright (c) 2007-2016 Basho Technologies, Inc.  All Rights Reserved.
 %%
@@ -67,7 +67,7 @@ Arg -> string : strip('$1').
   
 Erlang code.
 
-append_atom({_, X}, {number, B}) -> {atom, X ++ riakshell_util:to_list(B)};
+append_atom({_, X}, {number, B}) -> {atom, X ++ riak_shell_util:to_list(B)};
 append_atom({_, X}, {_,      B}) -> {atom, X ++ B}.
 
 make_atom({atom, A}) -> list_to_atom(A).

--- a/src/connection_EXT.erl
+++ b/src/connection_EXT.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% connection management extension for riakshell
+%% connection management extension for riak_shell
 %%
 %% Copyright (c) 2007-2016 Basho Technologies, Inc.  All Rights Reserved.
 %%
@@ -21,7 +21,7 @@
 %% -------------------------------------------------------------------
 -module(connection_EXT).
 
--include("riakshell.hrl").
+-include("riak_shell.hrl").
 
 -export([
          help/1
@@ -39,19 +39,19 @@
         ]).
 
 help(show_nodes) ->
-    "Type 'show_nodes;' to see which nodes riakshell is connected to.";
+    "Type 'show_nodes;' to see which nodes riak_shell is connected to.";
 help(show_cookie) ->
-    "Type 'show_cookie;' to see what the Erlang cookie is for riakshell. The riakshell needs to have the same cookie as the riak nodes you are connecting to.";
+    "Type 'show_cookie;' to see what the Erlang cookie is for riak_shell. The riak_shell needs to have the same cookie as the riak nodes you are connecting to.";
 help(ping) ->
     "Typing 'ping;' will ping all the nodes specified in the config file and print the results. Typing 'ping 'dev1@127.0.0.1';' will ping a particular node. You need to replace dev1 etc with your actual node name";
 help(reconnect) ->
-    "Typing 'reconnect;' will try to connect you to one of the nodes listed in your riakshell.config. It will try each node until it succeeds (or doesn't). To connect to a specific node (or one not in your riakshell.config please use the connect command.";
+    "Typing 'reconnect;' will try to connect you to one of the nodes listed in your riak_shell.config. It will try each node until it succeeds (or doesn't). To connect to a specific node (or one not in your riak_shell.config please use the connect command.";
 help(connect) ->
-    "You can connect to a specific node (whether in your riakshell.config or not) by typing 'connect 'dev1@127.0.0.1';' substituting your node name for dev1. You may need to change the Erlang cookie to do this. There is a command 'reconnect' which can be used to try all the nodes in your riakshell.config file.";
+    "You can connect to a specific node (whether in your riak_shell.config or not) by typing 'connect 'dev1@127.0.0.1';' substituting your node name for dev1. You may need to change the Erlang cookie to do this. There is a command 'reconnect' which can be used to try all the nodes in your riak_shell.config file.";
 help(connection_prompt) ->
     "Type 'connection_prompt on;' to display the connection status in the prompt, or 'connection_prompt off; to disable it";
 help(show_connection) ->
-    "This shows which riak nodes riakshell is connected to".
+    "This shows which riak nodes riak_shell is connected to".
 
 show_nodes(State) ->
     Msg = io_lib:format("The connected nodes are: ~p", [nodes()]),
@@ -62,7 +62,7 @@ show_cookie(#state{cookie = Cookie} = State) ->
     {Msg, State}.
 
 ping(#state{config = Config} = State) ->
-    Nodes = riakshell_shell:read_config(Config, nodes, []),
+    Nodes = riak_shell:read_config(Config, nodes, []),
     FoldFn = fun(Node, {Msg, S}) ->
                      {Msg2, S2} = ping2(S, Node),
                      {[Msg2] ++ Msg, S2}
@@ -88,10 +88,10 @@ ping2(State, Node) ->
     {Msg, State}.
     
 show_connection(#state{has_connection = false} = State) ->
-    {"Riakshell is not connected to riak", State};
+    {"riak_shell is not connected to riak", State};
 show_connection(#state{has_connection = true,
                        connection     = {Node, Port}} = State) ->
-    Msg = io_lib:format("Riakshell is connected to: ~p on port ~p", 
+    Msg = io_lib:format("riak_shell is connected to: ~p on port ~p",
                         [Node, Port]), 
     {Msg, State}. 
 

--- a/src/connection_srv.erl
+++ b/src/connection_srv.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% supervisor for the protocol buffers connection for riakshell
+%% supervisor for the protocol buffers connection for riak_shell
 %%
 %% Copyright (c) 2007-2016 Basho Technologies, Inc.  All Rights Reserved.
 %%
@@ -84,7 +84,7 @@ handle_call({run_sql_query, SQL}, _From, #state{connection = Connection} = State
                     Hdr = [binary_to_list(X) || X <- Header],
                     Rs = [begin
                               Row = tuple_to_list(RowTuple),
-                              [riakshell_util:to_list(X) || X <- Row]
+                              [riak_shell_util:to_list(X) || X <- Row]
                           end || RowTuple <- Rows],
                     case {Hdr, Rs} of
                         {[], []} -> 

--- a/src/connection_sup.erl
+++ b/src/connection_sup.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% supervisor for the protocol buffers connection for riakshell
+%% supervisor for the protocol buffers connection for riak_shell
 %%
 %% Copyright (c) 2007-2016 Basho Technologies, Inc.  All Rights Reserved.
 %%

--- a/src/debug_EXT.erl
+++ b/src/debug_EXT.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% debug extension for riakshell
+%% debug extension for riak_shell
 %%
 %% Copyright (c) 2007-2016 Basho Technologies, Inc.  All Rights Reserved.
 %%
@@ -30,7 +30,7 @@
          observer/1
         ]).
 
--include("riakshell.hrl").
+-include("riak_shell.hrl").
 
 help(observer) ->
     "Typing 'observer;' starts the Erlang observer application.";
@@ -47,7 +47,7 @@ observer(#state{} = State) ->
     {"Observer started", State#state{log_this_cmd = false}}. 
 
 load(#state{} = State) -> 
-    NewState = riakshell_shell:register_extensions(State),
+    NewState = riak_shell:register_extensions(State),
     {"Modules reloaded.", NewState#state{log_this_cmd = false}}.
 
   

--- a/src/history_EXT.erl
+++ b/src/history_EXT.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% history extension for riakshell
+%% history extension for riak_shell
 %%
 %% Copyright (c) 2007-2016 Basho Technologies, Inc.  All Rights Reserved.
 %%
@@ -21,7 +21,7 @@
 %% -------------------------------------------------------------------
 -module(history_EXT).
 
--include("riakshell.hrl").
+-include("riak_shell.hrl").
 
 -export([
          help/1
@@ -54,11 +54,11 @@ clear_history(S) ->
 show_history(#state{history = Hist} = S) ->
     Msg1 = io_lib:format("The history contains:~n", []),
     FormatFn = fun({N, Cmd}) ->
-                       Cmd2 = riakshell_util:pretty_pr_cmd(Cmd),
+                       Cmd2 = riak_shell_util:pretty_pr_cmd(Cmd),
                        {N, io_lib:format("~s", [Cmd2])}
                end,
     Hist2 = [FormatFn(X) || X <- Hist],
-    Msg2 = riakshell_util:printkvs(lists:reverse(Hist2)),
+    Msg2 = riak_shell_util:printkvs(lists:reverse(Hist2)),
     {Msg1 ++ Msg2, S}.
 
 h(S, N) -> history(S, N).
@@ -71,7 +71,7 @@ history(#state{history = H} = S, N) when is_integer(N) andalso
             {Msg1, S};
         {N, Cmd} ->
             Msg2 = io_lib:format("rerun (~p)> ~s~n", [N, Cmd]),
-            {Msg3, NewS} = riakshell_shell:handle_cmd(Cmd, S),
+            {Msg3, NewS} = riak_shell:handle_cmd(Cmd, S),
             {Msg2 ++ Msg3, NewS}
     end;
 history(S, Value) ->

--- a/src/log_EXT.erl
+++ b/src/log_EXT.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% The logging extention for riakshell
+%% The logging extention for riak_shell
 %%
 %% Copyright (c) 2007-2016 Basho Technologies, Inc.  All Rights Reserved.
 %%
@@ -35,7 +35,7 @@
          show_log_status/1
         ]).
 
--include("riakshell.hrl").
+-include("riak_shell.hrl").
 
 help(regression_log)  ->
     "Type 'regression_log \"myregresion.log\" ;' to run a regression. This will replay the log and check the results are the same " ++
@@ -97,7 +97,7 @@ replay_fold_fn() ->
                     {Msgs, N, S};
                 true ->
                     Msg1 = io_lib:format("replay (~p)> ~s\n", [N, Cmd]),
-                    {Msg2, NewS} = riakshell_shell:handle_cmd(Cmd, S),
+                    {Msg2, NewS} = riak_shell:handle_cmd(Cmd, S),
                     {[Msg1 ++ Msg2 ++ "\n" | Msgs], N + 1, NewS}
             end
     end.
@@ -108,7 +108,7 @@ regression_fold_fn() ->
                 false ->
                     {Msgs, N, S};
                 true ->
-                    {Msg2, NewS} = riakshell_shell:handle_cmd(Cmd, S),
+                    {Msg2, NewS} = riak_shell:handle_cmd(Cmd, S),
                     Msgs2 = case lists:flatten(Msg2)  of
                                 Res -> 
                                     Msgs;

--- a/src/riak_shell.app.src
+++ b/src/riak_shell.app.src
@@ -1,6 +1,6 @@
 %% -*- tab-width: 4;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ts=4 sw=4 et
-{application, riakshell,
+{application, riak_shell,
  [
   {description, "REPL for Riak"},
   {vsn, git},
@@ -9,6 +9,6 @@
                   stdlib
                  ]},
   {registered, []},
-  {mod, {riakshell_app, []}},
+  {mod, {riak_shell_app, []}},
   {env, []}
  ]}.

--- a/src/riak_shell.erl
+++ b/src/riak_shell.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% The main shell runner file for riakshell
+%% The main shell runner file for riak_shell
 %%
 %% Copyright (c) 2007-2016 Basho Technologies, Inc.  All Rights Reserved.
 %%
@@ -19,7 +19,7 @@
 %% under the License.
 %%
 %% -------------------------------------------------------------------
--module(riakshell_shell).
+-module(riak_shell).
 
 %% main export
 -export([
@@ -29,14 +29,14 @@
 
 %% various extensions like history which runs an old command
 %% and load which reloads EXT modules need to call back into
-%% riakshell_shell
+%% riak_shell
 -export([
          register_extensions/1,
          handle_cmd/2,
          read_config/3
         ]).
 
--include("riakshell.hrl").
+-include("riak_shell.hrl").
 
 start(Config) ->
     Fun = fun() ->
@@ -136,7 +136,7 @@ left_trim(X)                     -> X.
 run_cmd([{atom, Fn} | _T] = Toks, Cmd, State) ->
     case lists:member(normalise(Fn), [atom_to_list(X) || X <- ?IMPLEMENTED_SQL_STATEMENTS]) of
         true  -> run_sql_command(Cmd, State);
-        false -> run_riakshell_cmd(Toks, State)
+        false -> run_riak_shell_cmd(Toks, State)
     end;
 run_cmd(_Toks, Cmd, State) ->
     {"Invalid Command: " ++ Cmd, State#state{cmd_error = true}}.
@@ -166,7 +166,7 @@ run_sql_command(Cmd, State) ->
             {Msg2, State}
     end.
 
-run_riakshell_cmd(Toks, State) ->
+run_riak_shell_cmd(Toks, State) ->
     case cmdline_parser:parse(Toks) of
         {ok, {{Fn, Arity}, Args}} ->
             Cmd = toks_to_string(Toks),
@@ -186,8 +186,8 @@ run_riakshell_cmd(Toks, State) ->
         end.
 
 toks_to_string(Toks) ->
-    Cmd = [riakshell_util:to_list(TkCh) || {_, TkCh} <- Toks],
-    _Cmd2 = riakshell_util:pretty_pr_cmd(lists:flatten(Cmd)).
+    Cmd = [riak_shell_util:to_list(TkCh) || {_, TkCh} <- Toks],
+    _Cmd2 = riak_shell_util:pretty_pr_cmd(lists:flatten(Cmd)).
 
 add_cmd_to_history(Cmd, #state{history = Hs} = State) ->
     N = case Hs of
@@ -241,7 +241,7 @@ cut_mod(Mod) ->
 make_prompt(S = #state{count       = SQLN,
                        partial_cmd = []}) ->
     Prefix = make_prefix(S),
-    Prompt =  Prefix ++ "riakshell(" ++ integer_to_list(SQLN) ++ ")>",
+    Prompt =  Prefix ++ "riak_shell(" ++ integer_to_list(SQLN) ++ ")>",
     {Prompt, S#state{count = SQLN + 1}};
 make_prompt(S) ->
     Prompt = "->",
@@ -299,8 +299,8 @@ read_config(Config, Key, Default) when is_list(Config) andalso
 register_extensions(#state{} = S) ->
     %% the application may already be loaded to don't check
     %% the return value
-    _ = application:load(riakshell),
-    {ok, Mods} = application:get_key(riakshell, modules),
+    _ = application:load(riak_shell),
+    {ok, Mods} = application:get_key(riak_shell, modules),
     %% this might be a call to reload modules so delete
     %% and purge them first
     ReloadFn = fun(X) ->
@@ -376,7 +376,7 @@ print_exts(E) ->
     Grouped = group(E, []),
     lists:flatten([begin
                        io_lib:format("~nExtension '~s' provides:~n", [Mod]) ++
-                       riakshell_util:printkvs(Fns)
+                       riak_shell_util:printkvs(Fns)
                    end || {Mod, Fns} <- Grouped]).
 
 group([], Acc) ->

--- a/src/riak_shell_app.erl
+++ b/src/riak_shell_app.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% riakshell application riakshell
+%% riak_shell application riak_shell
 %%
 %% Copyright (c) 2007-2016 Basho Technologies, Inc.  All Rights Reserved.
 %%
@@ -19,7 +19,7 @@
 %% under the License.
 %%
 %% -------------------------------------------------------------------
--module(riakshell_app).
+-module(riak_shell_app).
 
 -behaviour(application).
 
@@ -44,18 +44,18 @@ boot([DebugStatus | Rest]) ->
     case Rest of
         [FileName, RunFileAs] when RunFileAs =:= "replay"     orelse
                                    RunFileAs =:= "regression" ->
-            ok = application:start(riakshell),
-            Config = application:get_all_env(riakshell),
-            {ReturnStatus, Msg} = riakshell_shell:start(Config, FileName, RunFileAs),
+            ok = application:start(riak_shell),
+            Config = application:get_all_env(riak_shell),
+            {ReturnStatus, Msg} = riak_shell:start(Config, FileName, RunFileAs),
             io:format(lists:flatten(Msg) ++ "~n", []),
             case ReturnStatus of
                 ok    -> halt(1);
                 error -> halt()
             end;
         [] -> 
-            ok = application:start(riakshell),
-            Config = application:get_all_env(riakshell),
-            user_drv:start(['tty_sl -c -e', {riakshell_shell, start, [Config]}]);
+            ok = application:start(riak_shell),
+            Config = application:get_all_env(riak_shell),
+            user_drv:start(['tty_sl -c -e', {riak_shell, start, [Config]}]);
         Other -> 
             io:format("Exit invalid args ~p~n", [Other]),
             exit({invalid_args, Other})

--- a/src/riak_shell_util.erl
+++ b/src/riak_shell_util.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% utility functions for riakshell
+%% utility functions for riak_shell
 %%
 %% Copyright (c) 2007-2016 Basho Technologies, Inc.  All Rights Reserved.
 %%
@@ -19,7 +19,7 @@
 %% under the License.
 %%
 %% -------------------------------------------------------------------
--module(riakshell_util).
+-module(riak_shell_util).
 
 -export([
          printkvs/1,

--- a/src/shell_EXT.erl
+++ b/src/shell_EXT.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% The main shell extention file for riakshell
+%% The main shell extention file for riak_shell
 %%
 %% Copyright (c) 2007-2016 Basho Technologies, Inc.  All Rights Reserved.
 %%
@@ -23,7 +23,7 @@
 
 %% implements the shell main functions as extensions
 
--include("riakshell.hrl").
+-include("riak_shell.hrl").
 
 %% export a help function
 -export([


### PR DESCRIPTION
Since `riak_` is the Basho de facto standard, rename all modules to match.  The script, however, has a dash to match things like `riak-admin`.
