### PR TITLE
Synchronize Testing Output

### DIFF
--- a/src/shell_EXT.erl
+++ b/src/shell_EXT.erl
@@ -34,11 +34,14 @@
 -export([
          quit/1,
          q/1,
-         show_config/1
+         show_config/1,
+         show_version/1
          ]).
 
 help(q) -> 
     help(quit);
+help(show_version) ->
+    "Type 'show_version;' to see the versions of riak_shell and SQL.";
 help(show_config) ->
     "Type 'show_config;' to print the config in the shell.";
 help(quit) ->
@@ -52,4 +55,8 @@ quit(_State) ->
 
 show_config(#state{config = C} = S) ->
     Msg = io_lib:format("The config is ~p~n", [C]),
+    {Msg, S}.
+
+show_version(#state{version = V} = S) ->
+    Msg = io_lib:format("~s~n", [V]),
     {Msg, S}.


### PR DESCRIPTION
Currently the `loop_TEST/3` function takes a message which returns the results of the previous request.  This leads to great confusion in the output since there is a delay between the response and the command to be tested.  Before https://github.com/basho/riak_shell/pull/15,  `loop/1` only had the state.  This change still returns the expected message back to `riak_test`, but will print to stdout immediately after the command instead of waiting for the message to go `round the block.

Also add the `show_version` function to allow for the version to be tested via a script.
