### PR TITLE
Update tsqueryresp to {ok, {_, _}}

### DIFF
--- a/src/connection_srv.erl
+++ b/src/connection_srv.erl
@@ -80,7 +80,7 @@ handle_call({run_sql_query, SQL}, _From, #state{connection = Connection} = State
     Reply = case riakc_ts:'query'(Connection, SQL) of
                 {error, {ErrNo, Binary}} -> 
                     io_lib:format("Error (~p): ~s", [ErrNo, Binary]);
-                {Header, Rows} -> 
+                {ok, {Header, Rows}} ->
                     Hdr = [binary_to_list(X) || X <- Header],
                     Rs = [begin
                               Row = tuple_to_list(RowTuple),


### PR DESCRIPTION
This change is require because of https://github.com/basho/riak-erlang-client/pull/276. Both success and error now have the same shape.
