### PR TITLE
Tweak help text

### DIFF
--- a/src/connection_EXT.erl
+++ b/src/connection_EXT.erl
@@ -46,7 +46,7 @@ help(show_cookie) ->
     "are connecting to.";
 help(ping) ->
     "Typing `ping;` will ping all the nodes specified in the config file~n"
-    "and print the results. Typing `ping 'dev1@127.0.0.1';` will ping~n"
+    "and print the results. Typing `ping dev1@127.0.0.1;` will ping~n"
     "a particular node. You need to replace dev1 etc with your actual~n"
     "node name";
 help(reconnect) ->
@@ -57,7 +57,7 @@ help(reconnect) ->
     "please use the connect command.";
 help(connect) ->
     "You can connect to a specific node (whether in your riak_shell.config~n"
-    "or not) by typing `connect 'dev1@127.0.0.1';` substituting your~n"
+    "or not) by typing `connect dev1@127.0.0.1;` substituting your~n"
     "node name for dev1.~n~n"
     "You may need to change the Erlang cookie to do this.~n~n"
     "See also the `reconnect` command.";

--- a/src/connection_EXT.erl
+++ b/src/connection_EXT.erl
@@ -39,31 +39,31 @@
         ]).
 
 help(show_nodes) ->
-    "Type 'show_nodes;' to see which nodes riak-shell is connected to.";
+    "Type `show_nodes;` to see which nodes riak-shell is connected to.";
 help(show_cookie) ->
-    "Type 'show_cookie;' to see what the Erlang cookie is for riak-shell.~n"
+    "Type `show_cookie;` to see what the Erlang cookie is for riak-shell.~n"
     "The riak-shell needs to have the same cookie as the riak nodes you~n"
     "are connecting to.";
 help(ping) ->
-    "Typing 'ping;' will ping all the nodes specified in the config file~n"
-    "and print the results. Typing 'ping \"dev1@127.0.0.1\"; will ping~n"
+    "Typing `ping;` will ping all the nodes specified in the config file~n"
+    "and print the results. Typing `ping 'dev1@127.0.0.1';` will ping~n"
     "a particular node. You need to replace dev1 etc with your actual~n"
     "node name";
 help(reconnect) ->
-    "Typing 'reconnect;' will try to connect you to one of the nodes~n"
+    "Typing `reconnect;` will try to connect you to one of the nodes~n"
     "listed in your riak_shell.config. It will try each node until it~n"
     "succeeds (or doesn't).~n~n"
     "To connect to a specific node (or one not in your riak_shell.config)~n"
     "please use the connect command.";
 help(connect) ->
     "You can connect to a specific node (whether in your riak_shell.config~n"
-    "or not) by typing 'connect \"dev1@127.0.0.1\";' substituting your~n"
+    "or not) by typing `connect 'dev1@127.0.0.1';` substituting your~n"
     "node name for dev1.~n~n"
     "You may need to change the Erlang cookie to do this.~n~n"
-    "See also the 'reconnect' command.";
+    "See also the `reconnect` command.";
 help(connection_prompt) ->
-    "Type 'connection_prompt on;' to display the connection status in~n"
-    "the prompt, or 'connection_prompt off; to disable it.~n~n"
+    "Type `connection_prompt on;` to display the connection status in~n"
+    "the prompt, or `connection_prompt off;` to disable it.~n~n"
     "Unicode support in your terminal is highly recommended.";
 help(show_connection) ->
     "This shows which riak node riak-shell is connected to".
@@ -152,7 +152,7 @@ connection_prompt(Cmd, State, off) ->
     Msg = io_lib:format("Connection Prompt turned off", []),
     {Cmd#command{response = Msg}, State#state{show_connection_status = false}};
 connection_prompt(Cmd, State, Toggle) ->
-    ErrMsg = io_lib:format("Invalid parameter passed to connection_prompt ~p. Should be 'off' or 'on'.", [Toggle]),
+    ErrMsg = io_lib:format("Invalid parameter passed to connection_prompt ~p. Should be `off` or `on`.", [Toggle]),
     {Cmd#command{response  = ErrMsg,
                  cmd_error = true}, State}.
                               

--- a/src/debug_EXT.erl
+++ b/src/debug_EXT.erl
@@ -33,10 +33,10 @@
 -include("riak_shell.hrl").
 
 help(observer) ->
-    "Typing 'observer;' starts the Erlang observer application.";
+    "Typing `observer;` starts the Erlang observer application.";
 help(load) ->
     "This is for developing extensions only.~n~n"
-    "Typing 'load;' reloads all the EXT modules after they have been~n"
+    "Typing `load;` reloads all the EXT modules after they have been~n"
     "compiled. This only works after a module has been compiled and~n"
     "loaded the first time.~n~n"
     "The first time you create a module you will need to stop and~n"

--- a/src/history_EXT.erl
+++ b/src/history_EXT.erl
@@ -38,12 +38,12 @@ help(h) ->
     help(history);
 help(history) ->
     "You can rerun a command by finding the command in the history list~n"
-    "with 'show_history;' and using the number next to it as the argument~n"
-    "to 'history' or 'h': 'history 3;' or 'h 3;' for example.";
+    "with `show_history;` and using the number next to it as the argument~n"
+    "to `history` or `h`: `history 3;` or `h 3;` for example.";
 help(clear_history) ->
-    "Type 'clear_history;' to delete all the history from the shell.";
+    "Type `clear_history;` to delete all the history from the shell.";
 help(show_history) ->
-    "Type 'show_history;' to list all the history in the shell.".
+    "Type `show_history;` to list all the history in the shell.".
 
 %% Reset prompt and clear history
 clear_history(Cmd, S) ->
@@ -74,7 +74,7 @@ history(Cmd, #state{history = H} = S, N) when is_integer(N) andalso
             {Cmd2#command{response = Msg2 ++ Cmd2#command.response}, NewS}
     end;
 history(Cmd, S, Value) ->
-    ErrMsg = io_lib:format("The value '~p' must be a positive integer.", 
+    ErrMsg = io_lib:format("The value `~p` must be a positive integer.", 
                         [Value]),
     {Cmd#command{response  = ErrMsg,
                  cmd_error = true}, S}.

--- a/src/log_EXT.erl
+++ b/src/log_EXT.erl
@@ -38,28 +38,28 @@
 -include("riak_shell.hrl").
 
 help(regression_log)  ->
-    "Type 'regression_log \"myregression.log\" ;' to run a regression.~n~n"
+    "Type `regression_log \"myregression.log\" ;` to run a regression.~n~n"
     "This will replay the log and check the results are the same~n"
     "as the last time you ran it. Useful for testing.~n"
     "You can run this in batch mode with the -r flag, see the README for details.";
 help(replay_log)  ->
-    "Type 'replay_log;' to replay the current logfile, or~n"
-    "'replay_log \"myfilename.log\";' to replay a different log file.~n"
+    "Type `replay_log;` to replay the current logfile, or~n"
+    "`replay_log \"myfilename.log\";` to replay a different log file.~n"
     "You can run this in batch mode with the -f flag, see the README for details.";
 help(show_log_status) ->
-    "Type 'show_log_status;' to see the logging status.";
+    "Type `show_log_status;` to see the logging status.";
 help(logfile) ->
-    "Type 'logfile \"mylogname\"'; to set the name of the logfile~n"
-    "or 'logfile default ;' to reset to the default log file which~n"
+    "Type `logfile \"mylogname\"`; to set the name of the logfile~n"
+    "or `logfile default ;` to reset to the default log file which~n"
     "can be set in the config.";
 help(date_log) ->
-    "Toggle adding a timestamp to the name of the log file with 'date_log on ;'~n"
-    "and off with 'date_log off ;'~n"
-    "The filename will be something like 'riak_shell.2016_02_15-16:42:22.log'~n"
+    "Toggle adding a timestamp to the name of the log file with `date_log on ;`~n"
+    "and off with `date_log off ;`~n"
+    "The filename will be something like \"riak_shell.2016_02_15-16:42:22.log\"~n"
     "You will get a new log file for each session of riak-shell.~n~n"
     "The default can be set in the config file.";
 help(log) ->
-    "Switch logging on with 'log on ;' and off with 'log off ;'~n~n"
+    "Switch logging on with `log on ;` and off with `log off ;`~n~n"
     "The default can be set in the config file.".
 
 regression_log(Cmd, #state{} = State, LogFile) ->
@@ -157,7 +157,7 @@ log(Cmd, State, off) ->
     {Cmd#command{response     = "Logging turned off.",
                  log_this_cmd = false}, State#state{logging = off}};
 log(Cmd, State, Toggle) ->
-    ErrMsg = io_lib:format("Invalid parameter passed to log ~p. Should be 'off' or 'on'.", [Toggle]),
+    ErrMsg = io_lib:format("Invalid parameter passed to log ~p. Should be `off` or `on`.", [Toggle]),
     {Cmd#command{response  = ErrMsg,
                  cmd_error = true}, State}.
 
@@ -168,7 +168,7 @@ date_log(Cmd, State, off) ->
     {Cmd#command{response = "Log files will not contain a date/time stamp."},
         State#state{date_log = off}};
 date_log(Cmd, State, Toggle) ->
-    ErrMsg = io_lib:format("Invalid parameter passed to log ~p. Should be 'off' or 'on'.", [Toggle]),
+    ErrMsg = io_lib:format("Invalid parameter passed to log ~p. Should be `off` or `on`.", [Toggle]),
     {Cmd#command{response  = ErrMsg,
                  cmd_error = true}, State}.
 

--- a/src/shell_EXT.erl
+++ b/src/shell_EXT.erl
@@ -42,11 +42,11 @@
 help(q) -> 
     help(quit);
 help(show_version) ->
-    "Type 'show_version;' to see the versions of riak_shell and SQL.";
+    "Type `show_version;` to see the versions of riak_shell and SQL.";
 help(show_config) ->
-    "Type 'show_config;' to print the config in the shell.";
+    "Type `show_config;` to print the config in the shell.";
 help(quit) ->
-    "Type 'quit;' or the shortcut 'q;' to quit the shell.".
+    "Type `quit;` or the shortcut `q;` to quit the shell.".
 
 q(Cmd, State) -> quit(Cmd, State).
 


### PR DESCRIPTION
Using backticks around command statements instead of apostrophes allows us to use apostrophes around atoms to limit user confusion.

Also address a couple of missing closing apostrophes (now backticks).
