### PR TITLE
Set riak-erlang-client to develop instead of master

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,5 +5,5 @@
            ]}.
 
 {deps, [
-        {riakc,   ".*", {git, "git://github.com/basho/riak-erlang-client", {branch, "master"}}}
+        {riakc,   ".*", {git, "git://github.com/basho/riak-erlang-client", {branch, "develop"}}}
        ]}.


### PR DESCRIPTION
Now there is a common `develop` branch on `riak-erlang-client` so use that one instead of `master` to be more consistent
