### PR TITLE
Translate timestamps from integer to ISO 8601 representation

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,5 +5,6 @@
            ]}.
 
 {deps, [
-        {riakc,   ".*", {git, "git://github.com/basho/riak-erlang-client", {branch, "develop"}}}
+        {riakc,   ".*", {git, "git://github.com/basho/riak-erlang-client", {branch, "develop"}}},
+        {jam,     ".*", {git, "git://github.com/basho/jam", {branch, "develop"}}},
        ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -6,5 +6,5 @@
 
 {deps, [
         {riakc,   ".*", {git, "git://github.com/basho/riak-erlang-client", {branch, "develop"}}},
-        {jam,     ".*", {git, "git://github.com/basho/jam", {branch, "develop"}}},
+        {jam,     ".*", {git, "git://github.com/basho/jam", {branch, "develop"}}}
        ]}.

--- a/src/connection_srv.erl
+++ b/src/connection_srv.erl
@@ -78,7 +78,8 @@ init([ShellRef, Nodes]) ->
     {ok, NewState}.
 
 map_timestamp({Int, timestamp}) ->
-    jam_iso8601:to_string(Int, [{precision, 3}]);
+    %% We currently only support millisecond accuracy (10^3).
+    jam_iso8601:to_string(jam:from_epoch(Int, 3));
 map_timestamp({Value, _Type}) ->
     Value.
 


### PR DESCRIPTION
Ready for review. Depends on new `jam` library and riak-erlang-client branch `feature-jrd-ts_datatypes` (basho/riak-erlang-client#303)
