### PR TITLE
RTS-1296: Add ability to specify clique table format

### DIFF
--- a/bin/riak-shell
+++ b/bin/riak-shell
@@ -25,11 +25,12 @@ DEBUG="debug_off"
 CONFIG="{{runner_etc_dir}}/riak_shell"
 DEFAULT_LOGFILE="{{runner_log_dir}}/riak_shell/riak_shell"
 NODE="riak_shell@127.0.0.1"
+FORMAT="human"
 RUNFILE=false
 FILETORUN=""
 RUNFILEAS=""
 
-while getopts "c:df:hn:r:" OPT; do
+while getopts "c:df:hn:r:t:" OPT; do
     case $OPT in
         c)
           CONFIG=$OPTARG
@@ -44,7 +45,7 @@ while getopts "c:df:hn:r:" OPT; do
           ;;
         h)
           echo "Usage:"
-          echo "$0 -c <config> -d -f <replay_file> -n <node_name> -r <regression_file>"
+          echo "$0 -c <config> -d -f <replay_file> -n <node_name> -r <regression_file> -t <human|csv|json>"
           exit 1
           ;;
         n)
@@ -54,6 +55,9 @@ while getopts "c:df:hn:r:" OPT; do
           RUNFILE=true
           FILETORUN=$OPTARG
           RUNFILEAS="regression"
+          ;;
+        t)
+          FORMAT=$OPTARG
           ;;
         \?)
           exit 1
@@ -71,7 +75,7 @@ cd "${0%/*}"
 # Make sure another instance is not already running
 RESULT="$($ERTS_PATH/erl -noshell -run init stop -name $NODE 2>&1)"
 if [ -z "$RESULT" ]; then
-    $ERTS_PATH/erl -run riak_shell_app boot $DEBUG "$DEFAULT_LOGFILE" "$FILETORUN" "$RUNFILEAS" -noshell -config $CONFIG -noinput -pa ../lib/riak_shell*/ebin -pa ../lib/*/ebin -name $NODE
+    $ERTS_PATH/erl -run riak_shell_app boot $DEBUG "$FORMAT" "$DEFAULT_LOGFILE" "$FILETORUN" "$RUNFILEAS" -noshell -config $CONFIG -noinput -pa ../lib/riak_shell*/ebin -pa ../lib/*/ebin -name $NODE
 else
     rm -f erl_crash.dump
     script=$0

--- a/include/riak_shell.hrl
+++ b/include/riak_shell.hrl
@@ -26,6 +26,7 @@
     date_log               = off :: on | off,
     debug                  = off :: on | off,
     extensions             = [],
+    format                 = "human" :: string(),
     has_connection         = false :: boolean(),
     history                = [],
     logfile                = undefined,

--- a/include/riak_shell.hrl
+++ b/include/riak_shell.hrl
@@ -2,7 +2,7 @@
 -define(GREENTICK, [9989]).
 -define(REDCROSS,  [10060]).
 
--define(VERSION_NUMBER, "0.9").
+-define(VERSION_NUMBER, "1.4").
 
 -record(command, {
     %% these fields are used to convey information about the

--- a/src/connection_srv.erl
+++ b/src/connection_srv.erl
@@ -89,7 +89,7 @@ format_table({"", _}) ->
 format_table({[[]], _}) ->
     "";
 format_table({String, _}) ->
-    lists:reverse(tl(lists:reverse(lists:flatten(String)))).
+    re:replace(lists:flatten(String), "\r", "", [global,{return,list}]).
 
 handle_call({run_sql_query, SQL, Format}, _From,
             #state{connection = Connection} = State) ->

--- a/src/riak_shell_app.erl
+++ b/src/riak_shell_app.erl
@@ -53,20 +53,20 @@ boot([DebugStatus | Rest]) ->
             on
     end,
     case Rest of
-        [DefaultLogFile, FileName, RunFileAs] when RunFileAs =:= "replay"     orelse
-                                                   RunFileAs =:= "regression" ->
+        [Format, DefaultLogFile, FileName, RunFileAs] when RunFileAs =:= "replay"     orelse
+                                                           RunFileAs =:= "regression" ->
             ok = application:start(riak_shell),
             Config = application:get_all_env(riak_shell),
-            {ReturnStatus, Msg} = riak_shell:start(Config, DefaultLogFile, FileName, RunFileAs, Debug),
+            {ReturnStatus, Msg} = riak_shell:start(Config, DefaultLogFile, FileName, RunFileAs, Debug, Format),
             io:format(lists:flatten(Msg) ++ "~n", []),
             case ReturnStatus of
                 ok    -> halt(1);
                 error -> halt()
             end;
-        [DefaultLogFile, [], []] ->
+        [Format, DefaultLogFile, [], []] ->
             ok = application:start(riak_shell),
             Config = application:get_all_env(riak_shell),
-            user_drv:start(['tty_sl -c -e', {riak_shell, start, [Config, DefaultLogFile]}]);
+            user_drv:start(['tty_sl -c -e', {riak_shell, start, [Config, DefaultLogFile, Format]}]);
         Other -> 
             io:format("Exit invalid args ~p~n", [Other]),
             exit({invalid_args, Other})


### PR DESCRIPTION
Previously all output used clique's "human" format which looks great, but is limited by the width of the screen. Now you can specify one of "human", "csv" or "json" with "human" being the default and "csv" being the testing default.
