### PR TITLE
reuse fp-parsing helper functions from riak_ql lexer

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,5 +6,6 @@
 
 {deps, [
         {riakc,   ".*", {git, "git://github.com/basho/riak-erlang-client", {branch, "develop"}}},
+        {riak_ql, ".*", {git, "git://github.com/basho/riak_ql", {branch, "develop"}}},
         {jam,     ".*", {git, "git://github.com/basho/jam", {branch, "develop"}}}
        ]}.

--- a/src/cmdline_lexer.xrl
+++ b/src/cmdline_lexer.xrl
@@ -46,8 +46,8 @@ Rules.
 {QUOTEDATOM} : {token, {atom,   string:strip(TokenChars, both, $')}}.
 {STRING}     : {token, {string, TokenChars}}.
 {INT}        : {token, {number, list_to_integer(TokenChars)}}.
-{FLOATDEC}   : {token, {number, make_float(TokenChars)}}.
-{FLOATSCI}   : {token, {number, make_float(TokenChars)}}.
+{FLOATDEC}   : {token, {number, riak_ql_lexer:fpdec_to_float(TokenChars)}}.
+{FLOATSCI}   : {token, {number, riak_ql_lexer:fpsci_to_float(TokenChars)}}.
 
 \- : {token, {hyphen,     TokenChars}}.
 \_ : {token, {underscore, TokenChars}}.
@@ -60,7 +60,3 @@ Rules.
 . : {token, {token, TokenChars}}.
 
 Erlang code.
-
-%% these are not yer fathers floats
-make_float("0" ++ _Rest = X) -> list_to_float(X);
-make_float(X)                -> list_to_float("0" ++ X). 


### PR DESCRIPTION
RTS-1313

Depends on https://github.com/basho/riak_ql/pull/136.

Use riak_ql_lexer.xrl FP-parsing helper functions needed to process scientific floats correctly. Specifically, don't crash on input like "1e1".
