### PR TITLE
Fix of float printing in the shell.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,9 @@
            ]}.
 
 {deps, [
-        {riakc,   ".*", {git, "git://github.com/basho/riak-erlang-client", {branch, "develop"}}},
-        {riak_ql, ".*", {git, "git://github.com/basho/riak_ql", {branch, "develop"}}},
-        {jam,     ".*", {git, "git://github.com/basho/jam", {branch, "develop"}}}
+        {riakc,    ".*",      {git, "git://github.com/basho/riak-erlang-client", {branch, "develop"}}},
+        {riak_ql,  ".*",      {git, "git://github.com/basho/riak_ql",            {branch, "develop"}}},
+        {jam,      ".*",      {git, "git://github.com/basho/jam",                {branch, "develop"}}},
+        {mochiweb, "2.9.0.*", {git, "git://github.com/basho/mochiweb.git",       {tag, "v2.9.0p2"}}},
+        {clique,   "0.3.*",   {git, "git://github.com/basho/clique.git",         {tag, "0.3.8"}}}
        ]}.

--- a/src/riak_shell_util.erl
+++ b/src/riak_shell_util.erl
@@ -82,7 +82,7 @@ split_lists_by_length(Strings, PerString, MaxLen) ->
 to_list(A) when is_atom(A)    -> atom_to_list(A);
 to_list(B) when is_binary(B)  -> binary_to_list(B);
 to_list(I) when is_integer(I) -> integer_to_list(I);
-to_list(F) when is_float(F)   -> float_to_list(F);
+to_list(F) when is_float(F)   -> mochinum:digits(F);
 to_list(L) when is_list(L)    -> L.
 
 pretty_pr_cmd(Cmd) ->


### PR DESCRIPTION
Before:

```
SELECT 555, 1.1, 1e1, 1.123e-2 from GeoCheckin WHERE time > 1452252523182 AND time < 1452252543182 AND region = 'South Atlantic' AND state = 'South Carolina';
```

Returned

```
+---+--------------------------+--------------------------+--------------------------+
|555|           1.1            |           10.0           |         0.01123          |
+---+--------------------------+--------------------------+--------------------------+
|555|1.10000000000000008882e+00|1.00000000000000000000e+01|1.12300000000000003986e-02|
+---+--------------------------+--------------------------+--------------------------+
```

Now it returns:

```
+---+---+----+-------+
|555|1.1|10.0|0.01123|
+---+---+----+-------+
|555|1.1|10.0|0.01123|
+---+---+----+-------+
```
