### PR TITLE
Added help for SQL commands in riak-shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,8 @@ mymodule_EXT.erl
 ```
 are considered to be riak-shell extension modules.
 
+NOTE: the part before `_EXT` must be lower-case only.
+
 All exported functions with an arity >= 1 are automaticaly exposed in riak-shell, with some exceptions.
 
 Exported functions with the following names will be silently ignored:
@@ -343,10 +345,14 @@ Exported functions with the following names will be silently ignored:
 * `'riak-admin'/N`
 
 Functions that share a name with the first keyword of supported SQL statements will likewise be ignored:
+* `sql/N`
 * `create/N`
+* `delete/N`
 * `describe/N`
+* `explain/N`
 * `insert/N`
 * `select/N`
+* `show/N`
 
 As additional SQL statements are supported adding them to the macro `IMPLEMENTED_SQL_STATEMENTS` in `riak_shell.hrl` will automatically make them available to riak-shell and exclude them from extensions.
 

--- a/include/riak_shell.hrl
+++ b/include/riak_shell.hrl
@@ -40,7 +40,9 @@
 %% cannot be used as command names in extensions
 %% these keywords are used to select which lexer-parser will be used as well
 -define(IMPLEMENTED_SQL_STATEMENTS, [
+                                     sql, % reserved for SQL help
                                      create,
+                                     delete,
                                      describe,
                                      explain,
                                      insert,

--- a/src/cmdline_parser.yrl
+++ b/src/cmdline_parser.yrl
@@ -72,7 +72,7 @@ Erlang code.
 append_atom({_, X}, {number, B}) -> {atom, X ++ riak_shell_util:to_list(B)};
 append_atom({_, X}, {_,      B}) -> {atom, X ++ B}.
 
-make_atom({atom, A}) -> list_to_atom(A).
+make_atom({atom, A}) -> list_to_atom(string:to_lower(A)).
 
 strip({number, V}) -> V;
 strip({string, V}) -> string:strip(V, both, $");

--- a/src/help.erl
+++ b/src/help.erl
@@ -35,7 +35,7 @@ help(Mod, Example, List) ->
     Msg4 = io_lib:format("~nFor SQL help type 'help SQL'", []),
     Msg1 ++ Msg2 ++ Msg3 ++ Msg4.
 
-help('SQL') ->
+help(sql) ->
     "The following SQL help commands are supported:~n"
         "CREATE   - using CREATE TABLE statements~n"
         "DELETE   - deleting data with DELETE FROM~n"
@@ -45,25 +45,25 @@ help('SQL') ->
         "SELECT   - querying data~n"
         "SHOW     - listing tables~n"
         "~n"
-        "SELECT can be extended with ORDER BY, GROUP BY, LIMIT, support arithmetic and has a "
-        "variety of fuctions like COUNT, SUM, MEAN, AVG, MAX, MIN, STDDEV, STDDEV_SAMP, STDDEV_POP~n"
+        "SELECT can be used with ORDER BY, GROUP BY and LIMIT clauses. It supports arithmetic on column values and has a "
+        "variety of aggregation functions: COUNT, SUM, MEAN, AVG, MAX, MIN, STDDEV, STDDEV_SAMP and STDDEV_POP~n"
         "~n"
         "To get more help type 'help SQL SELECT' (replacing SELECT "
         "with another statement as appropriate)";
-help('CREATE') ->
+help(create) ->
     "You can use the CREATE TABLE statement to create Time Series tables.~n"
         "An example of the format is shown below:~n"
         "~n"
-        "CREATE TABLE mytable (~n"
-        "   keyfield    VARCHAR   NOT NULL,~n"
-        "   timefield   TIMESTAMP NOT NULL,~n"
-        "   otherfield1 SINT64    NOT NULL,~n"
-        "   otherfield2 DOUBLE    NOT NULL,~n"
-        "   otherfield3 BOOLEAN,~n"
-        "   PRIMARY KEY (~n"
-        "     (keyfield, QUANTUM(timefield, 15, 'm')),~n"
-        "     keyfield, timefield~n"
-        "   )~n"
+        "(1)>CREATE TABLE mytable (~n"
+        "      keyfield    VARCHAR   NOT NULL,~n"
+        "      timefield   TIMESTAMP NOT NULL,~n"
+        "      otherfield1 SINT64    NOT NULL,~n"
+        "      otherfield2 DOUBLE    NOT NULL,~n"
+        "      otherfield3 BOOLEAN,~n"
+        "      PRIMARY KEY (~n"
+        "        (keyfield, QUANTUM(timefield, 15, 'm')),~n"
+        "         keyfield, timefield~n"
+        "      )~n"
         ");~n"
         "~n"
         "The valid field types are:~n"
@@ -74,33 +74,35 @@ help('CREATE') ->
         "* BOOLEAN   - true or false~n"
         "~n"
         "Fields can optionally be declared NOT NULL - (fields that are in the keys MUST "
-        "be set to NOT NULL.~n"
+        "be set to NOT NULL).~n"
         "~n"
-        "The QUANTUM function (which is not required) can be used to colocate data "
-        "in time slices on the ring. It takes 2 paramaters:~n"
+        "The QUANTUM function (which is not required, but recommended) can be used to co-locate data "
+        "in time slices on the ring. It takes 2 parameters:~n"
         "* a number~n"
         "* one of 's', 'm', 'h' or 'd' for second/minute/hour/day~n"
         "~n"
         "So in this example the data is quantized in 15 minute blocks~n"
         "~n"
+        "IT IS POSSIBLE TO CREATE HOT-SPOTS AND MAKE YOUR CLUSTER PERFORM POORLY WITH BADLY FORMATTED TABLES. "
+        "PLEASE READ THE ONLINE DOCUMENTATION THOROUGHLY.~n"
         "For more details please go to http://docs.basho.com/riak/ts~n";
-help('DELETE') ->
+help(delete) ->
     "You can use the DELETE FROM statement to delete a single Time Series record.~n"
         "An example of the format is shown below:~n"
         "~n"
-        "DELETE FROM mytable WHERE keyfield = 'keyvalue' AND timefield = '2016-11-30 19:30:00';~n"
+        "(1)>DELETE FROM mytable WHERE keyfield = 'keyvalue' AND timefield = '2016-11-30 19:30:00';~n"
         "~n"
         "The WHERE clause must uniquely identify a key.~n"
         "~n"
         "For more details please go to http://docs.basho.com/riak/ts~n";
-help('DESCRIBE') ->
+help(describe) ->
     "You can use the DESCRIBE statement to inspect a Time Series table."
         "An example of the format is shown below:~n"
         "~n"
-        "DESCRIBE mytable;~n"
+        "(1)>DESCRIBE mytable;~n"
         "~n"
         "For more details please go to http://docs.basho.com/riak/ts~n";
-help('EXPLAIN') ->
+help(explain) ->
     "You can use the EXPLAIN statement to see how a Time Series SELECT query will be executed."
         "This feature is EXPERIMENTAL and its output should not be relied upon."
         "Its output is subject to unsignaled change between releases."
@@ -110,37 +112,37 @@ help('EXPLAIN') ->
         "~n"
         "An example of the format is shown below:~n"
         "~n"
-        "EXPLAIN SELECT * FROM mytable WHERE keyfield = 'keyvalue' ~n"
-        "   AND timefield > '2016-11-30 19:30:00' ~n"
-        "   AND timefield > '2016-12-31 19:30:00';~n"
+        "(1)>EXPLAIN SELECT * FROM mytable WHERE keyfield = 'keyvalue' ~n"
+        "      AND timefield > '2016-11-30 19:30:00' ~n"
+        "      AND timefield > '2016-12-31 19:30:00';~n"
         "~n"
-        "An invalid SELECT query will results in EXPLAIN returning an error~n"
+        "An invalid SELECT query will result in EXPLAIN returning an error~n"
         "~n"
         "For more details please go to http://docs.basho.com/riak/ts~n";
 %% TODO ask @jgorlick about NULLs in strings and this help function
-help('INSERT') ->
+help(insert) ->
     "You can use the INSERT INTO statement to insert data into a Time Series table.~n"
-        "There are two formats that the INSERT INTO statment can use.~n"
+        "There are two formats that the INSERT INTO statement can use.~n"
         "~n"
         "(this example uses the table definition from 'help SQL CREATE')~n"
         "~n"
         "An example of the first format is shown below:~n"
         "~n"
-        "INSERT INTO mytable VALUES ('keyvalue', '2016-11-30 19:30:00', 123, 12.3, false);"
+        "(1)>INSERT INTO mytable VALUES ('keyvalue', '2016-11-30 19:30:00', 123, 12.3, false);"
         "~n"
         "Using this format you have to provide values for all columns - including those that "
         "can contain nulls.~n"
         "~n"
         "An example of the second format is shown below:~n"
         "~n"
-        "INSERT INTO mytable (keyfield, timefield, otherfield1, otherfield2) VALUES ('keyvalue', '2016-11-30 19:30:00', 123, 12.3);"
+        "(2)>INSERT INTO mytable (keyfield, timefield, otherfield1, otherfield2) VALUES ('keyvalue', '2016-11-30 19:30:00', 123, 12.3);"
         "~n"
         "In both of these formats multiple rows of data can be specified~n"
         "~n"
-        "INSERT INTO mytable VALUES ('keyvalue', '2016-11-30 19:30:00', 123, 12.3, false), ('newvalue', '2016-11-30 19:31:04' 456, 45.6, true);"
+        "(3)>INSERT INTO mytable VALUES ('keyvalue', '2016-11-30 19:30:00', 123, 12.3, false), ('newvalue', '2016-11-30 19:31:04' 456, 45.6, true);"
         "~n"
         "For more details please go to http://docs.basho.com/riak/ts~n";
-help('SELECT') ->
+help(select) ->
     "You can use the SELECT statement to query your Time Series data."
         "~n"
         "(this example uses the table definition from 'help SQL CREATE' "
@@ -148,15 +150,15 @@ help('SELECT') ->
         "~n"
         "An example of the format is shown below:~n"
         "~n"
-        "SELECT * FROM mytable where keyfield = 'keyvalue' and timefield > '2016-11-30 19:15:00' and timefield < '2016-11-30 19:45:00';~n"
+        "(1)>SELECT * FROM mytable where keyfield = 'keyvalue' and timefield > '2016-11-30 19:15:00' and timefield < '2016-11-30 19:45:00';~n"
         "~n"
-        "You can specify individual field names, and apply functions or arithmetic to them~n"
+        "You can specify individual field names, and apply functions or arithmetic to them:~n"
         "~n"
-        "SELECT otherfield1 FROM mytable where keyfield = 'keyvalue' and timefield > '2016-11-30 19:15:00' and timefield < '2016-11-30 19:45:00';~n"
+        "(2)>SELECT otherfield1 FROM mytable where keyfield = 'keyvalue' and timefield > '2016-11-30 19:15:00' and timefield < '2016-11-30 19:45:00';~n"
         "~n"
-        "SELECT otherfield1/2 FROM mytable where keyfield = 'keyvalue' and timefield > '2016-11-30 19:15:00' and timefield < '2016-11-30 19:45:00';~n"
+        "(3)>SELECT otherfield1/2 FROM mytable where keyfield = 'keyvalue' and timefield > '2016-11-30 19:15:00' and timefield < '2016-11-30 19:45:00';~n"
         "~n"
-        "SELECT MEAN(otherfield1) FROM mytable where keyfield = 'keyvalue' and timefield > '2016-11-30 19:15:00' and timefield < '2016-11-30 19:45:00';~n"
+        "(4)>SELECT MEAN(otherfield1) FROM mytable where keyfield = 'keyvalue' and timefield > '2016-11-30 19:15:00' and timefield < '2016-11-30 19:45:00';~n"
         "~n"
         "The functions supported are:~n"
         "* COUNT~n"
@@ -170,14 +172,16 @@ help('SELECT') ->
         "You can also decorate SELECT statements with ORDER BY, GROUP BY and LIMIT~n"
         "~n"
         "For more details please go to http://docs.basho.com/riak/ts~n";
-help('SHOW') ->
+help(show) ->
     "You can use the SHOW table to list all Time Series tables you have created."
         "An example of the format is shown below:~n"
         "~n"
+        "(1)>SHOW mytable;~n"
+        "~n"
         "For more details please go to http://docs.basho.com/riak/ts~n";
 help(Other) ->
-    Msg = io_lib:format("No help available for '~p'~n", [Other]),
-    Msg ++ help('SQL').
+    Msg = io_lib:format("No help available for '~p'~n~n", [Other]),
+    Msg ++ help(sql).
         
 %%
 %% Internal Fns
@@ -193,7 +197,7 @@ print_exts(E) ->
 group([], Acc) ->
     [{Mod, lists:sort(L)} || {Mod, L} <- lists:sort(Acc)];
 group([{Fn, Mod} | T], Acc) ->
-    Mod2 = shrink(Mod),
+    Mod2 = remove_EXT_from_module_name(Mod),
     NewAcc = case lists:keyfind(Mod2, 1, Acc) of
                  false ->
                      [{Mod2, [Fn]} | Acc];
@@ -202,5 +206,5 @@ group([{Fn, Mod} | T], Acc) ->
              end,
     group(T, NewAcc).
 
-shrink(Atom) ->
+remove_EXT_from_module_name(Atom) ->
     re:replace(atom_to_list(Atom), "_EXT", "", [{return, list}]).

--- a/src/help.erl
+++ b/src/help.erl
@@ -1,0 +1,206 @@
+%% -------------------------------------------------------------------
+%%
+%% The main shell runner file for riak_shell
+%%
+%% Copyright (c) 2007-2016 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(help).
+
+-export([
+         help/3,
+         help/1
+        ]).
+
+help(Mod, Example, List) ->
+    Msg1 = io_lib:format("The following functions are available~n", []),
+    Msg2 = print_exts(List),
+    Msg3 = io_lib:format("~nYou can get more help by calling help with the~n" ++
+                  "extension name and function name like 'help ~s ~s;'~n",
+              [Mod, Example]),
+    Msg4 = io_lib:format("~nFor SQL help type 'help SQL'", []),
+    Msg1 ++ Msg2 ++ Msg3 ++ Msg4.
+
+help('SQL') ->
+    "The following SQL help commands are supported:~n"
+        "CREATE   - using CREATE TABLE statements~n"
+        "DELETE   - deleting data with DELETE FROM~n"
+        "DESCRIBE - examining table structures~n"
+        "EXPLAIN  - understanding SELECT query execution paths~n"
+        "INSERT   - inserting data with INSERT INTO statements~n"
+        "SELECT   - querying data~n"
+        "SHOW     - listing tables~n"
+        "~n"
+        "SELECT can be extended with ORDER BY, GROUP BY, LIMIT, support arithmetic and has a "
+        "variety of fuctions like COUNT, SUM, MEAN, AVG, MAX, MIN, STDDEV, STDDEV_SAMP, STDDEV_POP~n"
+        "~n"
+        "To get more help type 'help SQL SELECT' (replacing SELECT "
+        "with another statement as appropriate)";
+help('CREATE') ->
+    "You can use the CREATE TABLE statement to create Time Series tables.~n"
+        "An example of the format is shown below:~n"
+        "~n"
+        "CREATE TABLE mytable (~n"
+        "   keyfield    VARCHAR   NOT NULL,~n"
+        "   timefield   TIMESTAMP NOT NULL,~n"
+        "   otherfield1 SINT64    NOT NULL,~n"
+        "   otherfield2 DOUBLE    NOT NULL,~n"
+        "   otherfield3 BOOLEAN,~n"
+        "   PRIMARY KEY (~n"
+        "     (keyfield, QUANTUM(timefield, 15, 'm')),~n"
+        "     keyfield, timefield~n"
+        "   )~n"
+        ");~n"
+        "~n"
+        "The valid field types are:~n"
+        "* VARCHAR~n"
+        "* TIMESTAMP - times~n"
+        "* SINT64    - integers~n"
+        "* DOUBLE    - floats~n"
+        "* BOOLEAN   - true or false~n"
+        "~n"
+        "Fields can optionally be declared NOT NULL - (fields that are in the keys MUST "
+        "be set to NOT NULL.~n"
+        "~n"
+        "The QUANTUM function (which is not required) can be used to colocate data "
+        "in time slices on the ring. It takes 2 paramaters:~n"
+        "* a number~n"
+        "* one of 's', 'm', 'h' or 'd' for second/minute/hour/day~n"
+        "~n"
+        "So in this example the data is quantized in 15 minute blocks~n"
+        "~n"
+        "For more details please go to http://docs.basho.com/riak/ts~n";
+help('DELETE') ->
+    "You can use the DELETE FROM statement to delete a single Time Series record.~n"
+        "An example of the format is shown below:~n"
+        "~n"
+        "DELETE FROM mytable WHERE keyfield = 'keyvalue' AND timefield = '2016-11-30 19:30:00';~n"
+        "~n"
+        "The WHERE clause must uniquely identify a key.~n"
+        "~n"
+        "For more details please go to http://docs.basho.com/riak/ts~n";
+help('DESCRIBE') ->
+    "You can use the DESCRIBE statement to inspect a Time Series table."
+        "An example of the format is shown below:~n"
+        "~n"
+        "DESCRIBE mytable;~n"
+        "~n"
+        "For more details please go to http://docs.basho.com/riak/ts~n";
+help('EXPLAIN') ->
+    "You can use the EXPLAIN statement to see how a Time Series SELECT query will be executed."
+        "This feature is EXPERIMENTAL and its output should not be relied upon."
+        "Its output is subject to unsignaled change between releases."
+        "~n"
+        "(this example uses the table definition from 'help SQL CREATE' "
+        "and the data from 'help SQL INSERT')~n"
+        "~n"
+        "An example of the format is shown below:~n"
+        "~n"
+        "EXPLAIN SELECT * FROM mytable WHERE keyfield = 'keyvalue' ~n"
+        "   AND timefield > '2016-11-30 19:30:00' ~n"
+        "   AND timefield > '2016-12-31 19:30:00';~n"
+        "~n"
+        "An invalid SELECT query will results in EXPLAIN returning an error~n"
+        "~n"
+        "For more details please go to http://docs.basho.com/riak/ts~n";
+%% TODO ask @jgorlick about NULLs in strings and this help function
+help('INSERT') ->
+    "You can use the INSERT INTO statement to insert data into a Time Series table.~n"
+        "There are two formats that the INSERT INTO statment can use.~n"
+        "~n"
+        "(this example uses the table definition from 'help SQL CREATE')~n"
+        "~n"
+        "An example of the first format is shown below:~n"
+        "~n"
+        "INSERT INTO mytable VALUES ('keyvalue', '2016-11-30 19:30:00', 123, 12.3, false);"
+        "~n"
+        "Using this format you have to provide values for all columns - including those that "
+        "can contain nulls.~n"
+        "~n"
+        "An example of the second format is shown below:~n"
+        "~n"
+        "INSERT INTO mytable (keyfield, timefield, otherfield1, otherfield2) VALUES ('keyvalue', '2016-11-30 19:30:00', 123, 12.3);"
+        "~n"
+        "In both of these formats multiple rows of data can be specified~n"
+        "~n"
+        "INSERT INTO mytable VALUES ('keyvalue', '2016-11-30 19:30:00', 123, 12.3, false), ('newvalue', '2016-11-30 19:31:04' 456, 45.6, true);"
+        "~n"
+        "For more details please go to http://docs.basho.com/riak/ts~n";
+help('SELECT') ->
+    "You can use the SELECT statement to query your Time Series data."
+        "~n"
+        "(this example uses the table definition from 'help SQL CREATE' "
+        "and the data from 'help SQL INSERT')~n"
+        "~n"
+        "An example of the format is shown below:~n"
+        "~n"
+        "SELECT * FROM mytable where keyfield = 'keyvalue' and timefield > '2016-11-30 19:15:00' and timefield < '2016-11-30 19:45:00';~n"
+        "~n"
+        "You can specify individual field names, and apply functions or arithmetic to them~n"
+        "~n"
+        "SELECT otherfield1 FROM mytable where keyfield = 'keyvalue' and timefield > '2016-11-30 19:15:00' and timefield < '2016-11-30 19:45:00';~n"
+        "~n"
+        "SELECT otherfield1/2 FROM mytable where keyfield = 'keyvalue' and timefield > '2016-11-30 19:15:00' and timefield < '2016-11-30 19:45:00';~n"
+        "~n"
+        "SELECT MEAN(otherfield1) FROM mytable where keyfield = 'keyvalue' and timefield > '2016-11-30 19:15:00' and timefield < '2016-11-30 19:45:00';~n"
+        "~n"
+        "The functions supported are:~n"
+        "* COUNT~n"
+        "* SUM~n"
+        "* MEAN and AVG~n"
+        "* MIN~n"
+        "* MAX~n"
+        "* STDEV and STDDEV_SAMP~n"
+        "* STDDEVPOP~n"
+        "~n"
+        "You can also decorate SELECT statements with ORDER BY, GROUP BY and LIMIT~n"
+        "~n"
+        "For more details please go to http://docs.basho.com/riak/ts~n";
+help('SHOW') ->
+    "You can use the SHOW table to list all Time Series tables you have created."
+        "An example of the format is shown below:~n"
+        "~n"
+        "For more details please go to http://docs.basho.com/riak/ts~n";
+help(Other) ->
+    Msg = io_lib:format("No help available for '~p'~n", [Other]),
+    Msg ++ help('SQL').
+        
+%%
+%% Internal Fns
+%%
+
+print_exts(E) ->
+    Grouped = group(E, []),
+    lists:flatten([begin
+                       io_lib:format("~nExtension '~s':~n", [Mod]) ++
+                           riak_shell_util:print_help(Fns)
+                   end || {Mod, Fns} <- Grouped]).
+
+group([], Acc) ->
+    [{Mod, lists:sort(L)} || {Mod, L} <- lists:sort(Acc)];
+group([{Fn, Mod} | T], Acc) ->
+    Mod2 = shrink(Mod),
+    NewAcc = case lists:keyfind(Mod2, 1, Acc) of
+                 false ->
+                     [{Mod2, [Fn]} | Acc];
+                 {Mod2, A2} ->
+                     lists:keyreplace(Mod2, 1, Acc, {Mod2, [Fn | A2]})
+             end,
+    group(T, NewAcc).
+
+shrink(Atom) ->
+    re:replace(atom_to_list(Atom), "_EXT", "", [{return, list}]).

--- a/src/riak_shell.erl
+++ b/src/riak_shell.erl
@@ -271,11 +271,10 @@ add_cmd_to_history(#command{cmd = Input}, #state{history = Hs} = State) ->
 run_ext({{help, 0}, []}, Cmd, #state{extensions = E} = State) ->
     Msg = help:help(shell, quit, E),
     {Cmd#command{response = Msg},  State};
-run_ext({{help, 1}, ['SQL']}, Cmd, State) ->
-    Msg = help:help('SQL'),
+run_ext({{help, 1}, [sql]}, Cmd, State) ->
+    Msg = help:help(sql),
     {Cmd#command{response = Msg}, State};
 run_ext({{help, 1}, [Mod]}, Cmd, #state{extensions = E} = State) ->
-    gg:format("Mod is ~p~n", [Mod]),
     ModAtom = list_to_atom(atom_to_list(Mod) ++ "_EXT"),
     Msg =
         case lists:filter(fun({_F, M}) when M =:= ModAtom -> true;
@@ -288,7 +287,7 @@ run_ext({{help, 1}, [Mod]}, Cmd, #state{extensions = E} = State) ->
         end,
     {Cmd#command{response = Msg},  State};
 %% the help funs are not passed the state and can't change it
-run_ext({{help, 2}, ['SQL', Fn]}, Cmd, State) ->
+run_ext({{help, 2}, [sql, Fn]}, Cmd, State) ->
     Msg = help:help(Fn),
     {Cmd#command{response = Msg}, State};
 run_ext({{help, 2}, [Mod, Fn]}, Cmd, State) ->

--- a/src/riak_shell.erl
+++ b/src/riak_shell.erl
@@ -51,6 +51,7 @@
 -define(DO_INCREMENT, true).
 -define(IN_TEST, false).
 -define(IN_PRODUCTION, true).
+-define(P, io_lib:format).
 
 start(Config, DefaultLogFile, Format) ->
     Fun = fun() ->
@@ -70,7 +71,7 @@ main(Config, DefaultLogFile, File, RunFileAs, Debug, Format) ->
     State = init(Config, DefaultLogFile, Debug, Format),
     case File of
         none -> io:format("version ~p, use 'quit;' or 'q;' to exit or " ++
-                          "'help;' for help~n", [State#state.version]),
+                              "'help;' for help~n", [State#state.version]),
                 loop(#command{}, State, ?DONT_INCREMENT, ?IN_PRODUCTION);
         File -> run_file(#command{}, State, File, RunFileAs)
     end.
@@ -82,14 +83,14 @@ run_file(Cmd, State, File, RunFileAs) ->
             NewS = State#state{has_connection = true,
                                connection     = {Node, Port}},
             {_Cmd, _NS} = case RunFileAs of
-                            "replay" ->
-                                handle_cmd("replay_log \"" ++ File ++ "\";", Cmd, NewS);
-                            "regression" ->
-                                handle_cmd("regression_log \"" ++ File ++ "\";", Cmd, NewS)
-                        end
+                              "replay" ->
+                                  handle_cmd("replay_log \"" ++ File ++ "\";", Cmd, NewS);
+                              "regression" ->
+                                  handle_cmd("regression_log \"" ++ File ++ "\";", Cmd, NewS)
+                          end
     after
         5000 ->
-            Msg = io_lib:format("Unable to connect to riak...", []),
+            Msg = ?P("Unable to connect to riak...", []),
             {Cmd#command{response  = Msg,
                          cmd_error = true}, State}
     end.
@@ -131,9 +132,9 @@ loop(Cmd, State, ShouldIncrement, IsProduction) ->
             Response = "Disconnected...",
             maybe_yield(Response, Cmd, NewState#state{has_connection = false,
                                                       connection     = none},
-                 ?DONT_INCREMENT, IsProduction);
+                        ?DONT_INCREMENT, IsProduction);
         Other ->
-            Response = io_lib:format("Unhandled message received is ~p~n", [Other]),
+            Response = ?P("Unhandled message received is ~p~n", [Other]),
             maybe_yield(Response, Cmd, NewState, ?DONT_INCREMENT, IsProduction)
     end.
 
@@ -161,8 +162,8 @@ handle_cmd(Input, #command{} = Cmd, #state{} = State) ->
             {Cmd2#command{response = ""}, State}
     end.
 
-% Convert hyphenated or underscored commands into single command names
-% Anything else is not valid
+%% Convert hyphenated or underscored commands into single command names
+%% Anything else is not valid
 full_cmd_name(Toks) ->
     full_cmd_name2(Toks, Toks, []).
 
@@ -202,7 +203,7 @@ left_trim(X)                     -> X.
 %% TODO add a riak-admin lexer/parser etc, etc
 run_cmd({invalid, _Toks}, Cmd, State) ->
     {Cmd#command{response  = "Invalid Command: " ++ Cmd#command.cmd,
-        cmd_error = true}, State};
+                 cmd_error = true}, State};
 run_cmd({Fn, Toks}, Cmd, State) ->
     case lists:member(Fn, [atom_to_list(X) || X <- ?IMPLEMENTED_SQL_STATEMENTS]) of
         true  -> run_sql_command(Cmd, State);
@@ -210,7 +211,7 @@ run_cmd({Fn, Toks}, Cmd, State) ->
     end.
 
 run_sql_command(Cmd, #state{has_connection = false} = State) ->
-    Msg = io_lib:format("Not connected to riak", []),
+    Msg = ?P("Not connected to riak", []),
     {Cmd#command{response  = Msg,
                  cmd_error = true}, State};
 run_sql_command(Cmd, State) ->
@@ -219,7 +220,7 @@ run_sql_command(Cmd, State) ->
         Toks = riak_ql_lexer:get_tokens(Input),
         case riak_ql_parser:parse(Toks) of
             {error, Err} ->
-                Msg1 = io_lib:format("SQL Parser error ~p", [Err]),
+                Msg1 = ?P("SQL Parser error ~p", [Err]),
                 {Cmd#command{response = Msg1}, State};
             {ok, _SQL} ->
                 %% the server is going to reparse
@@ -230,7 +231,7 @@ run_sql_command(Cmd, State) ->
                 {Cmd3, NewState2}
         end
     catch _:Error ->
-            Msg2 = io_lib:format("SQL Lexer error ~p", [Error]),
+            Msg2 = ?P("SQL Lexer error ~p", [Error]),
             {Cmd#command{response = Msg2},  State}
     end.
 
@@ -244,16 +245,16 @@ run_riak_shell_cmd(Toks, Cmd, State) ->
             Msg1 = try
                        Response2#command.response
                    catch Type:Err ->
-                       maybe_print_exception(State, Type, Err),
-                       "The extension did not return printable output. " ++
-                            "Please report this bug to the EXT developer."
+                           maybe_print_exception(State, Type, Err),
+                           "The extension did not return printable output. " ++
+                               "Please report this bug to the EXT developer."
                    end,
             {Response2#command{response = Msg1}, NewState3};
         Error ->
-            Msg2 = io_lib:format("Error: ~p", [Error]),
+            Msg2 = ?P("Error: ~p", [Error]),
             {Cmd#command{response  = Msg2,
                          cmd_error = true}, State}
-        end.
+    end.
 
 toks_to_string(Toks) ->
     Input = [riak_shell_util:to_list(TkCh) || {_, TkCh} <- Toks],
@@ -268,36 +269,35 @@ add_cmd_to_history(#command{cmd = Input}, #state{history = Hs} = State) ->
 
 %% help is a special function
 run_ext({{help, 0}, []}, Cmd, #state{extensions = E} = State) ->
-    Msg1 = io_lib:format("The following functions are available~n", []),
-    Msg2 = print_exts(E),
-    Msg3 = io_lib:format("~nYou can get more help by calling help with the~n" ++
-                             "extension name and function name like 'help shell quit;'", []),
-   {Cmd#command{response = Msg1 ++ Msg2 ++ Msg3},  State};
+    Msg = help:help(shell, quit, E),
+    {Cmd#command{response = Msg},  State};
+run_ext({{help, 1}, ['SQL']}, Cmd, State) ->
+    Msg = help:help('SQL'),
+    {Cmd#command{response = Msg}, State};
 run_ext({{help, 1}, [Mod]}, Cmd, #state{extensions = E} = State) ->
+    gg:format("Mod is ~p~n", [Mod]),
     ModAtom = list_to_atom(atom_to_list(Mod) ++ "_EXT"),
     Msg =
         case lists:filter(fun({_F, M}) when M =:= ModAtom -> true;
                              ({_F, _Mod}) -> false
                           end, E) of
-            [] ->
-                io_lib:format("No such extension found: ~ts. See 'help;'", [Mod]);
-            List ->
-                Msg1 = io_lib:format("The following functions are available~n", []),
-                Msg2 = print_exts(List),
-                Msg3 = io_lib:format("~nYou can get more help by calling help with the~n" ++
-                                         "extension name and function name like 'help ~s ~s;'", [Mod, element(1, hd(List))]),
-                Msg1 ++ Msg2 ++ Msg3
+            []   -> ?P("No such extension found: ~ts. See 'help;'", [Mod]);
+            List -> 
+                help:help(Mod, element(1, hd(List)), List)
         end,
-   {Cmd#command{response = Msg},  State};
+    {Cmd#command{response = Msg},  State};
 %% the help funs are not passed the state and can't change it
+run_ext({{help, 2}, ['SQL', Fn]}, Cmd, State) ->
+    Msg = help:help(Fn),
+    {Cmd#command{response = Msg}, State};
 run_ext({{help, 2}, [Mod, Fn]}, Cmd, State) ->
     Mod2 = extend_mod(Mod),
     Msg = try
               erlang:apply(Mod2, help, [Fn])
           catch Type:Err ->
-              maybe_print_exception(State, Type, Err),
-              io_lib:format("There is no help for ~p : ~p",
-                                [Mod, Fn])
+                  maybe_print_exception(State, Type, Err),
+                  ?P("There is no help for ~p : ~p",
+                     [Mod, Fn])
           end,
     {Cmd#command{response = Msg}, State};
 run_ext({{Ext, _Arity}, Args}, Cmd, #state{extensions = E} = State) ->
@@ -306,15 +306,15 @@ run_ext({{Ext, _Arity}, Args}, Cmd, #state{extensions = E} = State) ->
             try
                 erlang:apply(Mod, Fn, [Cmd, State] ++ Args)
             catch Type:Err ->
-                riak_shell:maybe_print_exception(State, Type, Err),
-                Msg1 = io_lib:format("Error: invalid function call : ~p:~p ~p", [Mod, Fn, Args]),
-                Mod2 = cut_mod(Mod),
-                {Cmd2, NewS} = run_ext({{help, 2}, [Mod2, Fn]}, Cmd, State),
-                {Cmd2#command{response  = Msg1 ++ "\n" ++ Cmd2#command.response,
-                              cmd_error = true} , NewS}
+                    riak_shell:maybe_print_exception(State, Type, Err),
+                    Msg1 = ?P("Error: invalid function call : ~p:~p ~p", [Mod, Fn, Args]),
+                    Mod2 = cut_mod(Mod),
+                    {Cmd2, NewS} = run_ext({{help, 2}, [Mod2, Fn]}, Cmd, State),
+                    {Cmd2#command{response  = Msg1 ++ "\n" ++ Cmd2#command.response,
+                                  cmd_error = true} , NewS}
             end;
         false ->
-            Msg = io_lib:format("Extension ~p not implemented.", [Ext]),
+            Msg = ?P("Extension ~p not implemented.", [Ext]),
             {Cmd#command{response  = Msg,
                          cmd_error = true}, State}
     end.
@@ -366,9 +366,9 @@ init(Config, DefaultLogFile, Debug, Format) ->
     _State5 = register_extensions(State4).
 
 set_version_string(State) ->
-    Vsn = lists:flatten(io_lib:format("riak_shell ~s/sql compiler ~b",
-                                      [?VERSION_NUMBER,
-                                      riak_ql_ddl_compiler:get_compiler_version()])),
+    Vsn = lists:flatten(?P("riak_shell ~s/sql compiler ~b",
+                           [?VERSION_NUMBER,
+                            riak_ql_ddl_compiler:get_compiler_version()])),
     State#state{version=Vsn}.
 
 set_logging_defaults(#state{config = Config} = State, DefaultLogFile) ->
@@ -473,28 +473,6 @@ print_errors([{Fn, Mods} | T]) ->
     [io:format("- ~p~n", [X]) || X <- Mods],
     print_errors(T).
 
-print_exts(E) ->
-    Grouped = group(E, []),
-    lists:flatten([begin
-                       io_lib:format("~nExtension '~s':~n", [Mod]) ++
-                       riak_shell_util:print_help(Fns)
-                   end || {Mod, Fns} <- Grouped]).
-
-group([], Acc) ->
-    [{Mod, lists:sort(L)} || {Mod, L} <- lists:sort(Acc)];
-group([{Fn, Mod} | T], Acc) ->
-    Mod2 = shrink(Mod),
-    NewAcc = case lists:keyfind(Mod2, 1, Acc) of
-                 false ->
-                     [{Mod2, [Fn]} | Acc];
-                 {Mod2, A2} ->
-                     lists:keyreplace(Mod2, 1, Acc, {Mod2, [Fn | A2]})
-             end,
-    group(T, NewAcc).
-
-shrink(Atom) ->
-    re:replace(atom_to_list(Atom), "_EXT", "", [{return, list}]).
-
 log(Cmd, #state{logging = off} = State) ->
     {Cmd#command{log_this_cmd = true}, State};
 log(#command{log_this_cmd = false} = Cmd, State) ->
@@ -516,8 +494,8 @@ log(Cmd, #state{logging      = on,
                                       ]),
     case file:open(File, [append, {encoding, utf8}]) of
         {ok, Id} ->
-            Msg = io_lib:format("{{command, ~p}, {result, \"" ++ R2 ++ "\"}}.~n",
-                                [Cmd#command.cmd]),
+            Msg = ?P("{{command, ~p}, {result, \"" ++ R2 ++ "\"}}.~n",
+                     [Cmd#command.cmd]),
             io:put_chars(Id, Msg),
             file:close(Id);
         Err  ->
@@ -536,32 +514,32 @@ maybe_print_exception(_State, _type, _Err) ->
 
 full_cmd_name_test() ->
     ?assertMatch(
-        {"one_two", _},
-        full_cmd_name([{atom, "One"},{underscore, "_"},{atom, "Two"}])
-    ),
+       {"one_two", _},
+       full_cmd_name([{atom, "One"},{underscore, "_"},{atom, "Two"}])
+      ),
     ?assertMatch(
-        {"one-two", _},
-        full_cmd_name([{atom, "One"},{hyphen, "-"},{atom, "Two"}])
-    ),
+       {"one-two", _},
+       full_cmd_name([{atom, "One"},{hyphen, "-"},{atom, "Two"}])
+      ),
     ?assertMatch(
-        {"simple", _},
-        full_cmd_name([{atom, "Simple"},{goofball, "-"},{blahblah, "Two"}])
-    ),
+       {"simple", _},
+       full_cmd_name([{atom, "Simple"},{goofball, "-"},{blahblah, "Two"}])
+      ),
     ?assertMatch(
-        {invalid, _},
-        full_cmd_name([{constant, "Simple"},{goofball, "-"},{blahblah, "Two"}])
-    ),
+       {invalid, _},
+       full_cmd_name([{constant, "Simple"},{goofball, "-"},{blahblah, "Two"}])
+      ),
     ?assertMatch(
-        {"one_two_three", _},
-        full_cmd_name([{atom, "One"},{underscore, "_"},{atom, "Two"},{underscore, "_"},{atom, "Three"}])
-    ),
+       {"one_two_three", _},
+       full_cmd_name([{atom, "One"},{underscore, "_"},{atom, "Two"},{underscore, "_"},{atom, "Three"}])
+      ),
     ?assertMatch(
-        {"one-two-three", _},
-        full_cmd_name([{atom, "One"},{hyphen, "-"},{atom, "Two"},{hyphen, "-"},{atom, "Three"}])
-    ),
+       {"one-two-three", _},
+       full_cmd_name([{atom, "One"},{hyphen, "-"},{atom, "Two"},{hyphen, "-"},{atom, "Three"}])
+      ),
     ?assertMatch(
-        {"one-two_three", _},
-        full_cmd_name([{atom, "One"},{hyphen, "-"},{atom, "Two"},{underscore, "_"},{atom, "Three"}])
-    ).
+       {"one-two_three", _},
+       full_cmd_name([{atom, "One"},{hyphen, "-"},{atom, "Two"},{underscore, "_"},{atom, "Three"}])
+      ).
 
 -endif.


### PR DESCRIPTION
The help is quite summary - but covers all SQL commands and some of the variants
of SELECT queries - simply pointing out functions and ORDER BY, GROUP BY and LIMIT

I have added all the features that will be in 1.5 (ie include DELETE, ORDER BY and
LIMIT).

The help text has been broken out into a module to enable non-technical review
of its contents to be made easier.
