### PR TITLE
Server-side crash reports crash riak-shell

### DIFF
--- a/src/connection_srv.erl
+++ b/src/connection_srv.erl
@@ -107,8 +107,8 @@ handle_call({run_sql_query, SQL, Format}, _From,
                 {error, Err} ->
                     Err2 = re:replace(Err, "[\r | \n | \t]", " ", [global, {return, list}]),
                     Err3 = re:replace(Err2, "[\" \"]+",    " ", [global, {return, list}]),
-                    Msg = "UNEXPECTED ERROR - if you have logging on please send your logfile to Basho (~p): ~s",
-                    io_lib:format(Msg, ["XXX", Err3])
+                    Msg = "UNEXPECTED ERROR - if you have logging on please send your logfile to Basho: ~s",
+                    io_lib:format(Msg, [Err3])
             end,
     {reply, Reply, State};
 handle_call(reconnect, _From, #state{shell_ref = _ShellRef} = State) ->

--- a/src/connection_srv.erl
+++ b/src/connection_srv.erl
@@ -105,6 +105,10 @@ handle_call({run_sql_query, SQL, Format}, _From,
                     Status = clique_status:table(Rs),
                     format_table(clique_writer:write([Status], Format));
                 {error, Err} ->
+                    %% a normal Erlang error message in the shell sprays over many lines
+                    %% these regexs just strip whitespace to make it more compact
+                    %% otherwise the screen just scrolls off and leaves the user bewildered
+                    %% if they are not an Erlang dev
                     Err2 = re:replace(Err, "[\r | \n | \t]", " ", [global, {return, list}]),
                     Err3 = re:replace(Err2, "[\" \"]+",    " ", [global, {return, list}]),
                     Msg = "UNEXPECTED ERROR - if you have logging on please send your logfile to Basho: ~s",


### PR DESCRIPTION
Partial fix for https://bashoeng.atlassian.net/browse/RTS-1094 (#33)

In this world an attempt is made to insert values into a non-existant table.

This itself is a bug - the existence of the table should be checked - instead a crash happens

This crash message is returned to the connection server in `riak_shel`l which then crashes.

This fix makes `riak-shell` well behaved in the presence of unknown crashes server-side
with a push to the user to report the bug to Basho.

The actual bug that triggered it will be fixed in a different PR