### PR TITLE
WIP ☠️ Bug fix for smart quotes/unicode in input

### DIFF
--- a/src/cmdline_lexer.xrl
+++ b/src/cmdline_lexer.xrl
@@ -72,7 +72,8 @@ Erlang code.
 
 toks_to_command(Toks) ->
     Input   = [riak_shell_util:to_list(TkCh) || {_, _, TkCh} <- Toks],
-    _Input2 = riak_shell_util:pretty_pr_cmd(lists:flatten(Input)) ++ ";".
+    Bin = riak_shell_util:pretty_pr_cmd(lists:flatten(Input)),
+    _Input2 = binary_to_list(Bin) ++ ";".
 
 lex(String) ->
     string(string:strip(String, both, ?SPACE)).

--- a/src/history_EXT.erl
+++ b/src/history_EXT.erl
@@ -54,7 +54,7 @@ show_history(Cmd, #state{history = Hist} = S) ->
     Msg1 = "The history contains:\n",
     FormatFn = fun({N, Cmd1}) ->
                        Cmd2 = riak_shell_util:pretty_pr_cmd(Cmd1),
-                       {N, io_lib:format("~s", [Cmd2])}
+                       {N, io_lib:format("~ts", [Cmd2])}
                end,
     Hist2 = [FormatFn(X) || X <- Hist],
     Msg2 = riak_shell_util:print_key_vals(lists:reverse(Hist2)),

--- a/src/riak_shell_util.erl
+++ b/src/riak_shell_util.erl
@@ -86,9 +86,14 @@ to_list(F) when is_float(F)   -> mochinum:digits(F);
 to_list(L) when is_list(L)    -> L.
 
 pretty_pr_cmd(Cmd) ->
-    Cmd2  = re:replace(Cmd,  "\n",   " ", [global, {return, list}]),
-    Cmd3  = re:replace(Cmd2, "[ ]+", " ", [global, {return, list}]),
-    _Cmd4 = re:replace(Cmd3, "^ ", "", [{return, list}]).
+    %% complex list-to-binary unicode dance to make
+    %% regexs work with unicode input
+    CmdBin = unicode:characters_to_binary(Cmd),
+    {ok, Regex1} = re:compile("(\n|[ ]+)", [unicode]),
+    CmdBin2 = re:replace(CmdBin,  Regex1,  " ",
+                         [global, {return, binary}]),
+    {ok, Regex2} = re:compile("^ ", [unicode]),
+    _CmdBin3 = re:replace(CmdBin2, Regex2, "", [{return, binary}]).
 
 datetime() ->
     {{Y, M, D}, {H, Mn, S}} = calendar:universal_time(),
@@ -106,3 +111,14 @@ datetime() ->
 
 pad(X) when is_integer(X) ->
     io_lib:format("~2.10.0B", [X]).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+pretty_pr_with_unicode_test() ->
+    %% 8217 is smart quotes
+    Input = [8217, 65, 8217],
+    Expected = unicode:characters_to_binary(Input),
+    ?assertEqual(Expected, pretty_pr_cmd(Input)).
+
+-endif.


### PR DESCRIPTION
Unicode in input was being handled correctly by the riak_shell
lexer/parser (and by the SQL one) but not by the cmd pretty printer

This is used in writing the history and the logs and it was borking
on unicode - in particular smart quotes inserted into SQL on pasting
from some editors.

The regular expression clean up and output munging is now unicode
friendly.

riak_shell doesn't log errored commands so it is hard to regression
test for this.