### PR TITLE
Bug fix for unicode in riak-shell

### DIFF
--- a/src/history_EXT.erl
+++ b/src/history_EXT.erl
@@ -62,7 +62,7 @@ show_history(Cmd, #state{history = Hist} = S) ->
     Msg1 = "The history contains:\n",
     FormatFn = fun({N, Cmd1}) ->
                        Cmd2 = riak_shell_util:pretty_pr_cmd(Cmd1),
-                       {N, io_lib:format("~s", [Cmd2])}
+                       {N, io_lib:format("~ts", [Cmd2])}
                end,
     Hist2 = [FormatFn(X) || X <- Hist],
     Msg2 = riak_shell_util:print_key_vals(lists:reverse(Hist2)),


### PR DESCRIPTION
Unicode in input was being handled correctly by the riak_shell
lexer/parser (and by the SQL one) but not by the cmd pretty printer

This is used in writing the history and the logs and it was borking
on unicode - in particular smart quotes inserted into SQL on pasting
from some editors.

The regular expression clean up and output munging is now unicode
friendly.

riak_shell doesn't log errored commands so it is hard to regression
test for this.