### PR TITLE
Update riak shell README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-riak-shell
+riak shell
 ---------
 
-A configurable, scriptable and extendable shell for riak.
+A configurable, scriptable, and extendable shell for Riak.
 
 It is designed to be built and deployed with Riak, and cannot
 trivially be built independently of a Riak installation.
@@ -9,10 +9,10 @@ trivially be built independently of a Riak installation.
 Goals
 -----
 
-The goals of riak-shell are to have a single shell that can:
+The goals of riak shell are to have a single shell that can:
 * run SQL commands
 * run `riak-admin` commands (**not implemented yet**)
-* be used a developer/devops tool for managing riak clusters
+* be used as a developer/devops tool for managing Riak clusters
 
 Current Capabilities
 --------------------
@@ -48,69 +48,23 @@ The shell is in the early stages. The following are well supported:
 The following is not yet supported:
 * riak-admin mode
 
-Running/Getting Started
+Usage
 -----------------------
+
+You can read all about running, using, and configuring riak shell on our [docs site](http://docs.basho.com/riak/ts/latest/using/riakshell/)
 
 `riak-shell` is installed in the same directory as `riak-admin`:
 ```
 ./riak-shell
 ```
 
-You get help on what is implemented in the riak-shell with the help command:
-```
-riak-shell (1)> help;
-```
-
-The current state is:
-```
-The following functions are available
-
-Extension 'connection':
-    connect, connection_prompt, ping, reconnect, show_connection, show_cookie
-    show_nodes
-
-Extension 'debug':
-    load, observer
-
-Extension 'history':
-    clear_history, h, history, show_history
-
-Extension 'log':
-    date_log, log, logfile, regression_log, replay_log, show_log_status
-
-Extension 'shell':
-    q, quit, show_config
-
-You can get more help by calling help with the
-extension name and function name like 'help shell quit;'
-```
-
-Configuration
--------------
-
-Configuration is in the file:
-```
-riak_shell.config
-```
-
-The following configuration items are available (`*` indicates the
-default value):
-
-```
-logging                = on | off*
-date_log               = on | off*
-logfile                = defaults to "riak_shell/riak_shell.log" under the Riak log folder
-cookie                 = the Erlang cookie used by the Riak cluster
-show_connection_status = true | false* show the green tick or red cross in the command line
-nodes                  = [ nodenames] a list of nodes to try and connect to on startup or 'reconnect;'
-```
 
 Command Line Flags
 ------------------
 
 There are 4 different configurations, two of which trigger batch mode.
 
-By default riak-shell swallows error messages, this makes it hard to develop new extensions. You can run it in debug mode as shown below:
+By default riak shell swallows error messages, this makes it hard to develop new extensions. You can run it in debug mode as shown below:
 ```
 ./riak-shell -d
 ```
@@ -120,223 +74,31 @@ You can pass in a different config file than `../etc/riak_shell.config`:
 ./riak-shell -c ../path/to/my.config
 ```
 
-You can run a riak-shell replay log in batch mode for scripting:
+You can run a riak shell replay log in batch mode for scripting:
 ```
 ./riak-shell -f ../path/to/my.log
 ```
 
-You can run a riak-shell regression log in batch mode for scripting:
+You can run a riak shell regression log in batch mode for scripting:
 ```
 ./riak-shell -r ../path/to/my.log
 ```
 
-Basic Usage
------------
 
-Show which node to which you are currently connected:
-```
-✅ riak-shell(5)>show_connection;
-riak-shell is connected to: 'dev1@127.0.0.1' on port 10017
-```
-
-To connect to a node:
-```
-✅ riak-shell(2)>connect 'dev2@127.0.0.1';
-"Trying to connect..."
-✅ riak-shell(4)>show_connection;
-riak-shell is connected to: 'dev2@127.0.0.1' on port 10027
-```
-**Note:** The node name must be an Erlang atom.
-
-To show the current configuration tuple:
-```
-✅ riak-shell(23)>show_config;
-The config is [{nodes,['dev1@127.0.0.1','dev2@127.0.0.1','dev3@127.0.0.1',
-                       'dev4@127.0.0.1','dev5@127.0.0.1','dev6@127.0.0.1',
-                       'dev7@127.0.0.1','dev8@127.0.0.1']},
-               {show_connection_status,true},
-               {cookie,riak},
-               {logging,on},
-               {logfile,"riak_shell.log"},
-               {included_applications,[]}]
-```
-
-Toggle the connection status flag.  Unicode support in the terminal is
-recommended when the flag is on.  It is **off** by default.
-```
-riak-shell(3)>connection_prompt on;
-Connection Prompt turned on
-✅ riak-shell(4)>connection_prompt off;
-Connection Prompt turned off
-```
-
-To show the current status of each node in your config file:
-```
-✅ riak-shell(11)>ping;
-'dev8@127.0.0.1': ❌ (disconnected)
-'dev7@127.0.0.1': ❌ (disconnected)
-'dev6@127.0.0.1': ❌ (disconnected)
-'dev5@127.0.0.1': ❌ (disconnected)
-'dev4@127.0.0.1': ❌ (disconnected)
-'dev3@127.0.0.1': ❌ (disconnected)
-'dev2@127.0.0.1': ✅ (connected)
-'dev1@127.0.0.1': ✅ (connected)
-```
-
-**Note:** The `ping` command is not logged.
-**Note:** The unicode connected/disconnected icons only appear if the connection_prompt is set to on - it is off by default.
-
-To retry connecting to a node in your config file:
-```
-✅ riak-shell(12)>reconnect;
-"Trying to reconnect..."
-✅ riak-shell(15)>show_connection;
-riak-shell is connected to: 'dev1@127.0.0.1' on port 10017
-```
-
-To find the current Erlang cookie:
-```
-✅ riak-shell(16)>show_cookie;
-Cookie is riak [actual riak]
-```
-
-To show the connected nodes:
-```
-✅ riak-shell(15)>show_connection;
-riak-shell is connected to: 'dev1@127.0.0.1' on port 10017
-```
-
-To start the Erlang `observer` debugger:
-```
-✅ riak-shell(25)>observer;
-Observer started
-```
-
-To show the history and replay a command:
-```
-✅ riak-shell(6)>show_history;
-The history contains:
-- 1: show_connection;
-- 2: ping;
-- 3: reconnect;
-
-✅ riak-shell(7)>h 1;
-rerun (1)> show_connection;
-riak-shell is connected to: 'dev1@127.0.0.1' on port 10017
-```
-
-To change the logfile and turn on logging:
-```
-✅ riak-shell(2)>logfile "mylogfile";
-Log file changed to "mylogfile"
-
-✅ riak-shell(3)>log on;
-Logging turned on.
-✅ riak-shell(4)>show_connection;
-riak-shell is connected to: 'dev1@127.0.0.1' on port 10017
-✅ riak-shell(5)>show_nodes;
-The connected nodes are: ['dev1@127.0.0.1','dev2@127.0.0.1']
-✅ riak-shell(6)>log off;
-Logging turned off.
-```
-**Note:** The logfile name must be a string.
-
-To replay a log:
-```
-✅ riak-shell(4)>replay_log "mylogfile.log";
-
-Replaying "mylogfile.log"
-replay (1)> show_connection;
-riak-shell is connected to: 'dev1@127.0.0.1' on port 10017
-replay (2)> show_nodes;
-The connected nodes are: ['dev1@127.0.0.1','dev2@127.0.0.1']
-```
-**Note:** If no logfile name is supplied, the default logfile is
-replayed.
-
-To verify the results of commands in a log file:
-```
-File "mylogfile" does not exist.
-✅ riak-shell(7)>regression_log "mylogfile.log";
-
-Regression Testing "mylogfile.log"
-No Regression Errors.
-```
-
-Or a failure:
-```
-✅ riak-shell(2)>regression_log "mylogfile.log";
-
-Regression Testing "mylogfile.log"
-Cmd "show_nodes; " (2) failed
-Got:
-- "The connected nodes are: ['dev1@127.0.0.1','dev2@127.0.0.1']"
-Expected:
-- "The connected nodes are: ['dev1@127.0.0.1','dev3@127.0.0.1']"
-```
-
-Regression logs can be integrated into riak_test trivially. Please see this test for an example:
-https://github.com/basho/riak_test/blob/riak_ts-develop/tests/ts_cluster_riak_shell_regression_log.erl
-
-To create a table and see its schema:
-```
-riak-shell(25)>CREATE TABLE GeoCheckin (myfamily varchar not null, myseries varchar not null, time  timestamp not null, weather  varchar not null, temperature double, PRIMARY KEY ((myfamily, myseries, quantum(time, 15, 'm')), myfamily, myseries, time));
-✅ riak-shell(26)>DESCRIBE GeoCheckin;
-+-----------+---------+-------+-----------+---------+--------+----+
-|  Column   |  Type   |Is Null|Primary Key|Local Key|Interval|Unit|
-+-----------+---------+-------+-----------+---------+--------+----+
-| myfamily  | varchar | false |     1     |    1    |        |    |
-| myseries  | varchar | false |     2     |    2    |        |    |
-|   time    |timestamp| false |     3     |    3    |   15   | m  |
-|  weather  | varchar | false |           |         |        |    |
-|temperature| double  | true  |           |         |        |    |
-+-----------+---------+-------+-----------+---------+--------+----+
-```
-
-To write data to a table:
-```
-✅ riak-shell(27)>INSERT INTO GeoCheckin (myfamily, myseries, time, weather, temperature) VALUES ('family1','series1',1,'snow',25.2);
-```
-
-To query a table:
-```
-✅ riak-shell(28)>SELECT time, weather, temperature FROM GeoCheckin WHERE myfamily='family1' AND myseries='series1' AND time > 0 AND time < 1000;
-+------------------------+-------+-----------+
-|          time          |weather|temperature|
-+------------------------+-------+-----------+
-|1970-01-01T00:00:00.001Z| snow  |      25.2 |
-|1970-01-01T00:00:00.002Z| rain  |      24.5 |
-|1970-01-01T00:00:00.003Z| rain  |      23.0 |
-|1970-01-01T00:00:00.004Z| sunny |      28.6 |
-|1970-01-01T00:00:00.005Z| sunny |      24.7 |
-|1970-01-01T00:00:00.006Z|cloudy |      32.9 |
-|1970-01-01T00:00:00.007Z|cloudy |      27.9 |
-|1970-01-01T00:00:00.008Z|  fog  |      34.9 |
-|1970-01-01T00:00:00.009Z|  fog  |      28.7 |
-|1970-01-01T00:00:00.01Z | hail  |      38.1 |
-+------------------------+-------+-----------+
-```
-
-To quit:
-```
-✅ riak-shell(29)>q;
-Toodle Ooh!
-```
-
-Extending The riak-shell
+Extending riak shell
 -----------------------
 
-riak-shell uses a 'magic' architecture with convention.
+riak shell uses a 'magic' architecture with convention.
 
 Riak modules with names like:
 ```
 mymodule_EXT.erl
 ```
-are considered to be riak-shell extension modules.
+are considered to be riak shell extension modules.
 
 NOTE: the part before `_EXT` must be lower-case only.
 
-All exported functions with an arity >= 1 are automaticaly exposed in riak-shell, with some exceptions.
+All exported functions with an arity >= 1 are automaticaly exposed in riak shell, with some exceptions.
 
 Exported functions with the following names will be silently ignored:
 * `module_info/0`
@@ -382,7 +144,7 @@ To be a good citizen you should add a clause to the help function like:
     "This is how you use my function";
 ```
 
-If you have a function with the same name that appears in 2 EXT modules riak-shell will not start. It will not check if the arities match. You may have the same function with different arities in the same module - but there is only one help call.
+If you have a function with the same name that appears in 2 EXT modules riak shell will not start. It will not check if the arities match. You may have the same function with different arities in the same module - but there is only one help call.
 
 As a convenience to the developer there is a module called:
 ```
@@ -395,7 +157,7 @@ riak-shell (11)>load;
 ```
 and can hot-load changes into the shell (it won't work on first-creation of a new EXT module, only on reloading). The only EXT that debug doesn't load is `debug_EXT` so please do not add functions to it.
 
-The riak-shell suppresses error messages that would otherwise be written to the console (for instance if the remote riak node goes down the protocol buffer connection is torn down). This makes debugging painful. You can stop this behaviour by starting riak-shell in the debug mode by starting it from the shell with the `-d` flag:
+The riak shell suppresses error messages that would otherwise be written to the console (for instance if the remote riak node goes down the protocol buffer connection is torn down). This makes debugging painful. You can stop this behaviour by starting riak shell in the debug mode by starting it from the shell with the `-d` flag:
 ```
 cd ~/riak_shell/bin
 ./riak-shell -d

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Command Line Flags
 
 There are 4 different configurations, two of which trigger batch mode.
 
-By default riak shell swallows error messages, this makes it hard to develop new extensions. You can run it in debug mode as shown below:
+By default riak shell swallows error messages, making it hard to develop new extensions. You can run it in debug mode as shown below:
 ```
 ./riak-shell -d
 ```
@@ -98,7 +98,7 @@ are considered to be riak shell extension modules.
 
 NOTE: the part before `_EXT` must be lower-case only.
 
-All exported functions with an arity >= 1 are automaticaly exposed in riak shell, with some exceptions.
+Exported functions with an arity >= 1 are automaticaly exposed in riak shell, with some exceptions.
 
 Exported functions with the following names will be silently ignored:
 * `module_info/0`


### PR DESCRIPTION
#Change all instances of 'riak-shell' that do NOT refer to the command to 'riak shell'. General copyediting, including: capitalization, punctuation, word order. Removed all the usage information that is a duplicate of the info at http://docs.basho.com/riak/ts/latest/using/riakshell/ and linked out to the docs site instead (where we can guarantee the info will be kept up-to-date per release).

Based on [DOC-527](https://bashoeng.atlassian.net/browse/DOC-527), for context.

Aimed this at the develop branch, but wasn't sure if it should go to master instead. Happy to move it. 